### PR TITLE
[Feat/#20] profile mod navigation

### DIFF
--- a/app/src/main/java/com/acon/acon/navigation/nested/ProfileNavigation.kt
+++ b/app/src/main/java/com/acon/acon/navigation/nested/ProfileNavigation.kt
@@ -92,9 +92,6 @@ internal fun NavGraphBuilder.profileNavigation(
                         popUpTo(ProfileRoute.Profile) { inclusive = false }
                     }
                 },
-                onNavigateToAreaVerification = {
-                    navController.navigate(AreaVerificationRoute.RequireAreaVerification)
-                },
                 onNavigateToCustomGallery = {
                     navController.navigate(ProfileRoute.GalleryList)
                 }

--- a/core/designsystem/src/main/java/com/acon/acon/core/designsystem/component/textfield/AconTextField.kt
+++ b/core/designsystem/src/main/java/com/acon/acon/core/designsystem/component/textfield/AconTextField.kt
@@ -57,6 +57,7 @@ fun AconTextField(
     val focusManager = LocalFocusManager.current
 
     val backgroundColor = when (status) {
+        TextFieldStatus.Empty -> AconColors.Gray9
         TextFieldStatus.Inactive -> AconColors.Gray9
         TextFieldStatus.Focused -> AconColors.Gray9
         TextFieldStatus.Active -> AconColors.Gray9
@@ -65,6 +66,7 @@ fun AconTextField(
     }
 
     val borderColor = when (status) {
+        TextFieldStatus.Empty -> AconColors.Gray6
         TextFieldStatus.Inactive -> AconColors.Gray6
         TextFieldStatus.Focused -> AconColors.Gray6
         TextFieldStatus.Active -> AconColors.Gray6
@@ -73,11 +75,12 @@ fun AconTextField(
     }
 
     val textColor = when (status) {
-        TextFieldStatus.Inactive -> AconColors.Gray5
-        TextFieldStatus.Focused -> AconColors.Gray5
+        TextFieldStatus.Empty -> AconColors.Gray6
+        TextFieldStatus.Inactive -> AconColors.White
+        TextFieldStatus.Focused -> AconColors.White
         TextFieldStatus.Active -> AconColors.White
-        TextFieldStatus.Error -> AconColors.Gray5
-        TextFieldStatus.Disabled -> AconColors.Gray5
+        TextFieldStatus.Error -> AconColors.White
+        TextFieldStatus.Disabled -> AconColors.White
     }
 
     val isEnabled = status != TextFieldStatus.Disabled
@@ -160,6 +163,7 @@ fun AconTextField(
 }
 
 sealed interface TextFieldStatus {
+    data object Empty: TextFieldStatus
     data object Inactive: TextFieldStatus
     data object Focused: TextFieldStatus
     data object Active: TextFieldStatus

--- a/data/src/main/kotlin/com/acon/acon/data/remote/OnboardingApi.kt
+++ b/data/src/main/kotlin/com/acon/acon/data/remote/OnboardingApi.kt
@@ -4,10 +4,11 @@ import com.acon.acon.data.dto.request.PostOnboardingResultRequest
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.POST
+import retrofit2.http.PUT
 
 interface OnboardingApi {
 
-    @POST("/api/v1/member/preference")
+    @PUT("/api/v1/members/preference")
     suspend fun postOnboardingResult(
         @Body body: PostOnboardingResultRequest
     ) : Response<Unit>

--- a/data/src/main/kotlin/com/acon/acon/data/remote/ProfileApi.kt
+++ b/data/src/main/kotlin/com/acon/acon/data/remote/ProfileApi.kt
@@ -18,7 +18,7 @@ interface ProfileApi {
 
     @GET("/api/v1/members/nickname/validate")
     suspend fun validateNickname(
-        @Query("nickname") nickname: String
+        @Query("nickname", encoded = true) nickname: String
     ): Response<Unit>
 
     @PATCH("/api/v1/members/me")

--- a/data/src/main/kotlin/com/acon/acon/data/repository/ProfileRepositoryImpl.kt
+++ b/data/src/main/kotlin/com/acon/acon/data/repository/ProfileRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.acon.acon.data.repository
 
 import com.acon.acon.data.datasource.remote.ProfileRemoteDataSource
 import com.acon.acon.data.error.runCatchingWith
+import com.acon.acon.domain.error.profile.ValidateNicknameError
 import com.acon.acon.domain.model.profile.PreSignedUrl
 import com.acon.acon.domain.model.profile.Profile
 import com.acon.acon.domain.repository.ProfileRepository
@@ -23,7 +24,7 @@ class ProfileRepositoryImpl @Inject constructor(
     }
 
     override suspend fun validateNickname(nickname: String): Result<Unit> {
-        return runCatchingWith() {
+        return runCatchingWith(*ValidateNicknameError.createErrorInstances()) {
             profileRemoteDataSource.validateNickname(nickname)
         }
     }

--- a/domain/src/main/java/com/acon/acon/domain/error/profile/ValidateNicknameError.kt
+++ b/domain/src/main/java/com/acon/acon/domain/error/profile/ValidateNicknameError.kt
@@ -1,0 +1,23 @@
+package com.acon.acon.domain.error.profile
+
+import com.acon.acon.domain.error.ErrorFactory
+import com.acon.acon.domain.error.RootError
+
+sealed class ValidateNicknameError : RootError() {
+
+    class UnsatisfiedCondition : ValidateNicknameError() {
+        override val code: Int = 40051
+    }
+    class AlreadyUsedNickname : ValidateNicknameError() {
+        override val code: Int = 40901
+    }
+
+    companion object : ErrorFactory {
+        override fun createErrorInstances(): Array<RootError> {
+            return arrayOf(
+                UnsatisfiedCondition(),
+                AlreadyUsedNickname()
+            )
+        }
+    }
+}

--- a/feature/profile/src/main/java/com/acon/acon/feature/profile/composable/component/CustomModalBottomSheet.kt
+++ b/feature/profile/src/main/java/com/acon/acon/feature/profile/composable/component/CustomModalBottomSheet.kt
@@ -1,6 +1,5 @@
 package com.acon.acon.feature.profile.composable.component
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -18,6 +17,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.dp
+import com.acon.acon.core.designsystem.noRippleClickable
 import com.acon.acon.core.designsystem.theme.AconTheme
 import com.acon.acon.feature.profile.R
 
@@ -41,7 +41,10 @@ fun CustomModalBottomSheet(
                 .padding(bottom = 30.dp)
         ) {
             Row(
-                modifier = Modifier.fillMaxWidth().padding(vertical = 12.dp, horizontal = 16.dp).clickable { onGallerySelect() },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 12.dp, horizontal = 16.dp)
+                    .noRippleClickable { onGallerySelect() },
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.Start
             ){
@@ -59,7 +62,13 @@ fun CustomModalBottomSheet(
                 )
             }
             Row(
-                modifier = Modifier.fillMaxWidth().padding(vertical = 12.dp, horizontal = 16.dp).clickable { onDefaultImageSelect() },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 12.dp, horizontal = 16.dp)
+                    .noRippleClickable {
+                        onDefaultImageSelect()
+                        onDismiss()
+                        },
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.Start
             ){

--- a/feature/profile/src/main/java/com/acon/acon/feature/profile/composable/component/CustomModalBottomSheet.kt
+++ b/feature/profile/src/main/java/com/acon/acon/feature/profile/composable/component/CustomModalBottomSheet.kt
@@ -44,7 +44,10 @@ fun CustomModalBottomSheet(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(vertical = 12.dp, horizontal = 16.dp)
-                    .noRippleClickable { onGallerySelect() },
+                    .noRippleClickable {
+                        onGallerySelect()
+                        onDismiss()
+                    },
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.Start
             ){

--- a/feature/profile/src/main/java/com/acon/acon/feature/profile/composable/component/ProfilePhotoBox.kt
+++ b/feature/profile/src/main/java/com/acon/acon/feature/profile/composable/component/ProfilePhotoBox.kt
@@ -18,29 +18,56 @@ import androidx.compose.material3.Icon
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
+import coil3.compose.AsyncImage
 import com.acon.acon.feature.profile.R
 
 @Composable
 fun ProfilePhotoBox(
     modifier: Modifier = Modifier,
     photoUri: String = "",
-){
+) {
     BoxWithConstraints(
         modifier = modifier.fillMaxSize()
     ) {
-        if (photoUri != ""){
+        if (photoUri.isNotBlank()) {
             val imageWidth = maxWidth
             Box(
-                modifier = Modifier.fillMaxSize().width(imageWidth).height(imageWidth).clip(CircleShape),
+                modifier = Modifier
+                    .fillMaxSize()
+                    .width(imageWidth)
+                    .height(imageWidth)
+                    .clip(CircleShape),
                 contentAlignment = Alignment.Center
             ) {
-                Image(
-                    painter = rememberAsyncImagePainter(Uri.parse(photoUri)),
-                    contentDescription = "선택한 프로필 사진",
-                    modifier = Modifier.fillMaxSize(),
-                    contentScale = ContentScale.Crop,
-                    alignment = Alignment.Center
-                )
+                when {
+                    photoUri.startsWith("content://") -> {
+                        Image(
+                            painter = rememberAsyncImagePainter(Uri.parse(photoUri)),
+                            contentDescription = "선택한 프로필 사진",
+                            modifier = Modifier.fillMaxSize(),
+                            contentScale = ContentScale.Crop,
+                            alignment = Alignment.Center
+                        )
+                    }
+
+                    photoUri.startsWith("http://") || photoUri.startsWith("https://") -> {
+                        AsyncImage(
+                            model = photoUri,
+                            contentDescription = "프로필 사진",
+                            modifier = Modifier.fillMaxSize(),
+                            contentScale = ContentScale.Crop
+                        )
+                    }
+
+                    else -> {
+                        Icon(
+                            modifier = Modifier.fillMaxSize(),
+                            imageVector = ImageVector.vectorResource(R.drawable.img_profile_basic_80),
+                            contentDescription = "Profile Image",
+                            tint = Color.Unspecified,
+                        )
+                    }
+                }
             }
         } else {
             Icon(

--- a/feature/profile/src/main/java/com/acon/acon/feature/profile/composable/screen/galleryGrid/composable/GalleryGridScreen.kt
+++ b/feature/profile/src/main/java/com/acon/acon/feature/profile/composable/screen/galleryGrid/composable/GalleryGridScreen.kt
@@ -3,7 +3,6 @@ package com.acon.acon.feature.profile.composable.screen.galleryGrid.composable
 import android.net.Uri
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -27,6 +26,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import coil3.compose.rememberAsyncImagePainter
 import com.acon.acon.core.designsystem.component.topbar.AconTopBar
+import com.acon.acon.core.designsystem.noRippleClickable
 import com.acon.acon.core.designsystem.theme.AconTheme
 import com.acon.acon.feature.profile.composable.screen.galleryGrid.GalleryGridState
 import com.acon.acon.feature.profile.composable.screen.galleryGrid.GalleryGridViewModel
@@ -125,7 +125,7 @@ fun PhotoItem(
     onClick: () -> Unit
 ) {
     Box(
-        modifier = Modifier.padding(2.dp).size(87.dp).clickable{ onClick() }
+        modifier = Modifier.padding(2.dp).size(87.dp).noRippleClickable{ onClick() }
     ) {
         Image(
             painter = rememberAsyncImagePainter(uri),

--- a/feature/profile/src/main/java/com/acon/acon/feature/profile/composable/screen/galleryList/composable/GalleryListScreen.kt
+++ b/feature/profile/src/main/java/com/acon/acon/feature/profile/composable/screen/galleryList/composable/GalleryListScreen.kt
@@ -2,7 +2,6 @@ package com.acon.acon.feature.profile.composable.screen.galleryList.composable
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -30,6 +29,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import coil3.compose.rememberAsyncImagePainter
 import com.acon.acon.core.designsystem.component.topbar.AconTopBar
+import com.acon.acon.core.designsystem.noRippleClickable
 import com.acon.acon.core.designsystem.theme.AconTheme
 import com.acon.acon.feature.profile.composable.screen.galleryList.Album
 import com.acon.acon.feature.profile.composable.screen.galleryList.GalleryListState
@@ -104,7 +104,7 @@ fun AlbumItem(album: Album, onAlbumSelected: (String, String) -> Unit) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .clickable { onAlbumSelected(album.id, album.name) }
+            .noRippleClickable { onAlbumSelected(album.id, album.name) }
             .padding(vertical = 8.dp, horizontal = 16.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.Start

--- a/feature/profile/src/main/java/com/acon/acon/feature/profile/composable/screen/profile/composable/ProfileScreen.kt
+++ b/feature/profile/src/main/java/com/acon/acon/feature/profile/composable/screen/profile/composable/ProfileScreen.kt
@@ -184,7 +184,7 @@ fun ProfileScreen(
                             Icon(
                                 imageVector = ImageVector.vectorResource(com.acon.acon.core.designsystem.R.drawable.ic_setting_w_28),
                                 contentDescription = stringResource(R.string.content_description_settings),
-                                tint = AconTheme.color.White
+                                tint = AconTheme.color.White,
                             )
                         }
                     },

--- a/feature/profile/src/main/java/com/acon/acon/feature/profile/composable/screen/profileMod/BirthdayVisualTransformation.kt
+++ b/feature/profile/src/main/java/com/acon/acon/feature/profile/composable/screen/profileMod/BirthdayVisualTransformation.kt
@@ -7,11 +7,11 @@ import androidx.compose.ui.text.input.VisualTransformation
 
 class BirthdayVisualTransformation : VisualTransformation {
     override fun filter(text: AnnotatedString): TransformedText {
-        val trimmed = text.text.filter { it.isDigit() } // 숫자만 허용
+        val trimmed = text.text.filter { it.isDigit() }
         val formatted = StringBuilder()
 
         for (i in trimmed.indices) {
-            if (i == 4 || i == 6) formatted.append(".") // 4번째, 6번째 위치에서 . 추가
+            if (i == 4 || i == 6) formatted.append(".")
             formatted.append(trimmed[i])
         }
 
@@ -22,16 +22,16 @@ class BirthdayVisualTransformation : VisualTransformation {
         override fun originalToTransformed(offset: Int): Int {
             return when {
                 offset <= 4 -> offset
-                offset <= 6 -> offset + 1 // YYYY. 추가 후 조정
-                else -> offset + 2 // YYYY.MM. 추가 후 조정
+                offset <= 6 -> offset + 1
+                else -> offset + 2
             }
         }
 
         override fun transformedToOriginal(offset: Int): Int {
             return when {
                 offset <= 4 -> offset
-                offset <= 7 -> offset - 1 // YYYY. 제거 후 조정
-                else -> offset - 2 // YYYY.MM. 제거 후 조정
+                offset <= 7 -> offset - 1
+                else -> offset - 2
             }
         }
     }

--- a/feature/profile/src/main/java/com/acon/acon/feature/profile/composable/screen/profileMod/ProfileModViewModel.kt
+++ b/feature/profile/src/main/java/com/acon/acon/feature/profile/composable/screen/profileMod/ProfileModViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.acon.acon.core.designsystem.component.textfield.TextFieldStatus
 import com.acon.acon.domain.repository.ProfileRepository
+import com.acon.acon.feature.profile.composable.screen.profile.ProfileUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -27,7 +28,7 @@ class ProfileModViewModel @Inject constructor(
 ) : AndroidViewModel(application), ContainerHost<ProfileModState, ProfileModSideEffect> {
 
     override val container = container<ProfileModState, ProfileModSideEffect>(ProfileModState()){
-        profileRepository.fetchProfile()
+        fetchUserProfileInfo()
     }
 
     fun onFocusChanged(isFocused: Boolean) = intent {
@@ -36,6 +37,20 @@ class ProfileModViewModel @Inject constructor(
                 nickNameFieldStatus = if (isFocused) TextFieldStatus.Focused else TextFieldStatus.Inactive,
                 birthdayFieldStatus = if (isFocused) TextFieldStatus.Focused else TextFieldStatus.Inactive
             )
+        }
+    }
+
+    private fun fetchUserProfileInfo() = intent {
+        viewModelScope.launch {
+            profileRepository.fetchProfile()
+                .onSuccess { profile ->
+                    reduce {
+                        state.copy(
+                            nickNameState = profile.nickname,
+                            birthdayState = if (profile.birthDate.isNullOrEmpty()) "" else profile.birthDate!!.filter { it.isDigit() }
+                        )
+                    }
+                }
         }
     }
 

--- a/feature/profile/src/main/java/com/acon/acon/feature/profile/composable/screen/profileMod/ProfileModViewModel.kt
+++ b/feature/profile/src/main/java/com/acon/acon/feature/profile/composable/screen/profileMod/ProfileModViewModel.kt
@@ -68,11 +68,18 @@ class ProfileModViewModel @Inject constructor(
                 this == '.' || this == '_'
     }
 
+    private val koreanCharRegex = Regex("[가-힣ㄱ-ㅎㅏ-ㅣ]")
 
     private var nicknameValidationJob: Job? = null
 
     fun onNicknameChanged(text: String) = intent {
         val filteredText = text.filter { it.isAllowedChar() }
+
+        var nicknameCount = 0
+        for (char in filteredText) {
+            nicknameCount += if (koreanCharRegex.matches(char.toString())) 2 else 1
+            if (nicknameCount > 16) break
+        }
 
         if (filteredText.isEmpty()) {
             reduce {
@@ -85,19 +92,9 @@ class ProfileModViewModel @Inject constructor(
             return@intent
         }
 
-        // 한글이 섞여있는 경우 버그 발생 (더 많이 써짐)
-        if (filteredText.length <= 16){
+        if (nicknameCount <= 16){
             reduce {
-                state.copy(nickNameState = filteredText, nicknameStatus = NicknameStatus.Typing)
-            }
-        }
-
-        val nicknameCount = filteredText.map { if (it in ('가'..'힣') + ('ㄱ'..'ㅎ') + ('ㅏ'..'ㅣ')) 2 else 1 }.sum()
-        if (nicknameCount <= 16) { //nicknameCount만 따로 업데이트 (딜레이 생기므로)
-            reduce {
-                state.copy(
-                    nicknameCount = nicknameCount
-                )
+                state.copy(nickNameState = filteredText, nicknameStatus = NicknameStatus.Typing, nicknameCount = nicknameCount)
             }
         }
 

--- a/feature/profile/src/main/java/com/acon/acon/feature/profile/composable/screen/profileMod/ProfileModViewModel.kt
+++ b/feature/profile/src/main/java/com/acon/acon/feature/profile/composable/screen/profileMod/ProfileModViewModel.kt
@@ -339,10 +339,15 @@ class ProfileModViewModel @Inject constructor(
 
         viewModelScope.launch {
             profileRepository.updateProfile(fileName, nickname, birthday)
-                .onSuccess { response -> // 성공 값 포함해서 Profile 화면으로 Navigation 처리
+                .onSuccess {
+                    intent {
+                        postSideEffect(ProfileModSideEffect.NavigateToProfileSuccess)
+                    }
                 }
-                .onFailure { response ->
-                    // 실패시 에러 처리
+                .onFailure {
+                    intent {
+                        postSideEffect(ProfileModSideEffect.NavigateToProfileFailed)
+                    }
                 }
 
         }
@@ -399,9 +404,16 @@ sealed class BirthdayStatus {
     data object Valid :BirthdayStatus()
 }
 
+enum class ProfileUpdateResult {
+    SUCCESS,
+    FAILURE
+}
+
 sealed interface ProfileModSideEffect {
     data object NavigateBack : ProfileModSideEffect
     data class NavigateToSettings(val packageName: String) : ProfileModSideEffect
     data object NavigateToCustomGallery : ProfileModSideEffect
     data class UpdateProfileImage(val imageUri: String?) : ProfileModSideEffect
+    data object NavigateToProfileSuccess : ProfileModSideEffect
+    data object NavigateToProfileFailed : ProfileModSideEffect
 }

--- a/feature/profile/src/main/java/com/acon/acon/feature/profile/composable/screen/profileMod/ProfileModViewModel.kt
+++ b/feature/profile/src/main/java/com/acon/acon/feature/profile/composable/screen/profileMod/ProfileModViewModel.kt
@@ -46,7 +46,7 @@ class ProfileModViewModel @Inject constructor(
                 .onSuccess { profile ->
                     reduce {
                         state.copy(
-                            //selectedPhotoUri = profile.image,
+                            selectedPhotoUri = profile.image,
                             nickNameState = profile.nickname,
                             birthdayState = profile.birthDate?.filter { it.isDigit() } ?: ""
                         )

--- a/feature/profile/src/main/java/com/acon/acon/feature/profile/composable/screen/profileMod/ProfileModViewModel.kt
+++ b/feature/profile/src/main/java/com/acon/acon/feature/profile/composable/screen/profileMod/ProfileModViewModel.kt
@@ -263,11 +263,9 @@ class ProfileModViewModel @Inject constructor(
         viewModelScope.launch {
             profileRepository.validateNickname(nickname)
                 .onSuccess { response ->
-                    Log.d("닉네임 검사", "성공 - $response")
                     isValid = true
                 }
                 .onFailure { response ->
-                    Log.d("닉네임 검사", "실패 - $response")
                     isValid = false
                     // 실패시 에러 처리
                 }
@@ -286,19 +284,17 @@ class ProfileModViewModel @Inject constructor(
         } else {
             viewModelScope.launch {
                 profileRepository.getPreSignedUrl()
-                    .onSuccess { result ->   //성공시 얻은 PreSignedUrl값 저장하고, fileName 저장하고, PUT 함수 부르기
+                    .onSuccess { result ->
                         reduce {
                             state.copy(
                                 uploadFileName = result.fileName,
                                 preSignedUrl = result.preSignedUrl
                             )
                         }
-                        Log.d("1) Url 받아오기 검사", "성공 - $result")
                         putPhotoToPreSignedUrl(Uri.parse(state.selectedPhotoUri), state.preSignedUrl)
                     }
                     .onFailure {
-                        // 실패시 에러처리 ?
-                        Log.d("1) Url 받아오기 검사", "성공 - $it")
+                        // 실패시 에러 처리
                     }
             }
         }
@@ -326,7 +322,6 @@ class ProfileModViewModel @Inject constructor(
             val response = client.newCall(request).execute()
 
             if (response.isSuccessful) {
-                Log.d("2) 사진 PUT 검사", "성공 - $response")
                 if (state.birthdayStatus == BirthdayStatus.Valid){
                     updateProfile(fileName = state.uploadFileName, nickname = state.nickNameState, birthday = state.birthdayState)
                 } else {
@@ -334,7 +329,6 @@ class ProfileModViewModel @Inject constructor(
                 }
             } else {
                 // PUT 실패 시 에러 처리
-                Log.d("2) 사진 PUT 검사", "실패 - $response")
             }
         } catch (e: Exception) {
             // ImageUri 갖고 바이너리 방식으로 변환 과정에서 에러 처리
@@ -345,12 +339,10 @@ class ProfileModViewModel @Inject constructor(
 
         viewModelScope.launch {
             profileRepository.updateProfile(fileName, nickname, birthday)
-                .onSuccess { response ->
-                    Log.d("3) 프로필 업뎃 검사", "성공 - $response")
+                .onSuccess { response -> // 성공 값 포함해서 Profile 화면으로 Navigation 처리
                 }
                 .onFailure { response ->
                     // 실패시 에러 처리
-                    Log.d("3) 프로필 업뎃 검사", "실패 - $response")
                 }
 
         }

--- a/feature/profile/src/main/java/com/acon/acon/feature/profile/composable/screen/profileMod/ProfileModViewModel.kt
+++ b/feature/profile/src/main/java/com/acon/acon/feature/profile/composable/screen/profileMod/ProfileModViewModel.kt
@@ -41,13 +41,13 @@ class ProfileModViewModel @Inject constructor(
         }
     }
 
-    fun fetchUserProfileInfo() = intent {
+    private fun fetchUserProfileInfo() = intent {
         viewModelScope.launch {
             profileRepository.fetchProfile()
                 .onSuccess { profile ->
                     reduce {
                         state.copy(
-                            //selectedPhotoUri = profile.image,
+                            selectedPhotoUri = profile.image,
                             nickNameState = profile.nickname,
                             birthdayState = profile.birthDate?.filter { it.isDigit() } ?: ""
                         )

--- a/feature/profile/src/main/java/com/acon/acon/feature/profile/composable/screen/profileMod/ProfileModViewModel.kt
+++ b/feature/profile/src/main/java/com/acon/acon/feature/profile/composable/screen/profileMod/ProfileModViewModel.kt
@@ -74,6 +74,17 @@ class ProfileModViewModel @Inject constructor(
     fun onNicknameChanged(text: String) = intent {
         val filteredText = text.filter { it.isAllowedChar() }
 
+        if (filteredText.isEmpty()) {
+            reduce {
+                state.copy(
+                    nickNameState = "",
+                    nicknameStatus = NicknameStatus.Empty,
+                    nickNameFieldStatus = TextFieldStatus.Empty
+                )
+            }
+            return@intent
+        }
+
         // 한글이 섞여있는 경우 버그 발생 (더 많이 써짐)
         if (filteredText.length <= 16){
             reduce {
@@ -127,13 +138,14 @@ class ProfileModViewModel @Inject constructor(
         if (digitsOnly.isEmpty()){
             reduce {
                 state.copy(
-                    birthdayState = digitsOnly,
+                    birthdayState = "",
                     birthdayStatus = BirthdayStatus.Empty,
-                    birthdayFieldStatus = TextFieldStatus.Focused
+                    birthdayFieldStatus = TextFieldStatus.Empty
                 )
             }
             return@intent
         }
+
         if (digitsOnly.length <= 8) { // 일단 8자 이내면 쓰는 게 다 보여야함
             reduce {
                 state.copy(

--- a/feature/profile/src/main/java/com/acon/acon/feature/profile/composable/screen/profileMod/ProfileModViewModel.kt
+++ b/feature/profile/src/main/java/com/acon/acon/feature/profile/composable/screen/profileMod/ProfileModViewModel.kt
@@ -187,41 +187,15 @@ class ProfileModViewModel @Inject constructor(
         return true
     }
 
-    fun showDialog() = intent {
+    fun showExitDialog() = intent {
         reduce {
-            state.copy(showDialog = true)
+            state.copy(showExitDialog = true)
         }
     }
 
-    fun hideDialog() = intent {
+    fun hideExitDialog() = intent {
         reduce {
-            state.copy(showDialog = false)
-        }
-    }
-
-    fun removeVerifiedArea(area: String) = intent {
-        val updatedList = state.verifiedAreaList.filterNot { it == area }
-
-        reduce {
-            state.copy(
-                verifiedAreaList = updatedList,
-                showAreaDeleteDialog = false
-            )
-        }
-    }
-
-    fun showAreaDeleteDialog(area: String) = intent {
-        reduce {
-            state.copy(
-                showAreaDeleteDialog = true,
-                selectedArea = area
-            )
-        }
-    }
-
-    fun hideAreaDeleteDialog() = intent {
-        reduce {
-            state.copy(showAreaDeleteDialog = false)
+            state.copy(showExitDialog = false)
         }
     }
 
@@ -388,9 +362,7 @@ data class ProfileModState(
 
     val verifiedAreaList: List<String> = listOf("쌍문동"),
 
-    val showDialog: Boolean = false,
-    val showAreaDeleteDialog: Boolean = false,
-    val selectedArea: String? = null,
+    val showExitDialog: Boolean = false,
 
     val requestPhotoPermission: Boolean = false,
     val showPermissionDialog: Boolean = false,

--- a/feature/profile/src/main/java/com/acon/acon/feature/profile/composable/screen/profileMod/ProfileModViewModel.kt
+++ b/feature/profile/src/main/java/com/acon/acon/feature/profile/composable/screen/profileMod/ProfileModViewModel.kt
@@ -28,7 +28,6 @@ class ProfileModViewModel @Inject constructor(
 ) : AndroidViewModel(application), ContainerHost<ProfileModState, ProfileModSideEffect> {
 
     override val container = container<ProfileModState, ProfileModSideEffect>(ProfileModState()){
-        fetchUserProfileInfo()
     }
 
     fun onFocusChanged(isFocused: Boolean) = intent {
@@ -40,16 +39,19 @@ class ProfileModViewModel @Inject constructor(
         }
     }
 
-    private fun fetchUserProfileInfo() = intent {
+    fun fetchUserProfileInfo() = intent {
         viewModelScope.launch {
             profileRepository.fetchProfile()
                 .onSuccess { profile ->
                     reduce {
                         state.copy(
+                            //selectedPhotoUri = profile.image,
                             nickNameState = profile.nickname,
-                            birthdayState = if (profile.birthDate.isNullOrEmpty()) "" else profile.birthDate!!.filter { it.isDigit() }
+                            birthdayState = profile.birthDate?.filter { it.isDigit() } ?: ""
                         )
                     }
+                    onNicknameChanged(state.nickNameState)
+                    onBirthdayChanged(state.birthdayState)
                 }
         }
     }

--- a/feature/profile/src/main/java/com/acon/acon/feature/profile/composable/screen/profileMod/ProfileModViewModel.kt
+++ b/feature/profile/src/main/java/com/acon/acon/feature/profile/composable/screen/profileMod/ProfileModViewModel.kt
@@ -29,6 +29,7 @@ class ProfileModViewModel @Inject constructor(
 ) : AndroidViewModel(application), ContainerHost<ProfileModState, ProfileModSideEffect> {
 
     override val container = container<ProfileModState, ProfileModSideEffect>(ProfileModState()){
+        fetchUserProfileInfo()
     }
 
     fun onFocusChanged(isFocused: Boolean) = intent {

--- a/feature/profile/src/main/java/com/acon/acon/feature/profile/composable/screen/profileMod/composable/ProfileModScreen.kt
+++ b/feature/profile/src/main/java/com/acon/acon/feature/profile/composable/screen/profileMod/composable/ProfileModScreen.kt
@@ -3,6 +3,7 @@ package com.acon.acon.feature.profile.composable.screen.profileMod.composable
 import android.content.Intent
 import android.net.Uri
 import android.provider.Settings
+import android.util.Log
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -26,8 +27,11 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -80,7 +84,6 @@ fun ProfileModScreenContainer(
     }
 
     LaunchedEffect(Unit) {
-        viewModel.fetchUserProfileInfo()
 
         viewModel.container.sideEffectFlow.collect { effect ->
             when (effect) {

--- a/feature/profile/src/main/java/com/acon/acon/feature/profile/composable/screen/profileMod/composable/ProfileModScreen.kt
+++ b/feature/profile/src/main/java/com/acon/acon/feature/profile/composable/screen/profileMod/composable/ProfileModScreen.kt
@@ -84,6 +84,8 @@ fun ProfileModScreenContainer(
     }
 
     LaunchedEffect(Unit) {
+        viewModel.fetchUserProfileInfo()
+
         viewModel.container.sideEffectFlow.collect { effect ->
             when (effect) {
                 is ProfileModSideEffect.NavigateToSettings -> {

--- a/feature/profile/src/main/java/com/acon/acon/feature/profile/composable/screen/profileMod/composable/ProfileModScreen.kt
+++ b/feature/profile/src/main/java/com/acon/acon/feature/profile/composable/screen/profileMod/composable/ProfileModScreen.kt
@@ -2,13 +2,10 @@ package com.acon.acon.feature.profile.composable.screen.profileMod.composable
 
 import android.content.Intent
 import android.net.Uri
-import android.os.Build
 import android.provider.Settings
 import androidx.activity.compose.BackHandler
-import androidx.annotation.RequiresApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -48,13 +45,13 @@ import com.acon.acon.core.designsystem.component.textfield.AconTextField
 import com.acon.acon.core.designsystem.component.textfield.TextFieldStatus
 import com.acon.acon.core.designsystem.component.textfield.addFocusCleaner
 import com.acon.acon.core.designsystem.component.topbar.AconTopBar
+import com.acon.acon.core.designsystem.noRippleClickable
 import com.acon.acon.core.designsystem.theme.AconTheme
 import com.acon.acon.core.utils.feature.permission.CheckAndRequestPhotoPermission
 import com.acon.acon.feature.profile.R
 import com.acon.acon.feature.profile.composable.component.CustomModalBottomSheet
 import com.acon.acon.feature.profile.composable.component.NicknameErrMessageRow
 import com.acon.acon.feature.profile.composable.component.ProfilePhotoBox
-import com.acon.acon.feature.profile.composable.component.VerifiedAreaChip
 import com.acon.acon.feature.profile.composable.screen.profileMod.BirthdayStatus
 import com.acon.acon.feature.profile.composable.screen.profileMod.BirthdayVisualTransformation
 import com.acon.acon.feature.profile.composable.screen.profileMod.NicknameStatus
@@ -255,7 +252,7 @@ fun ProfileModScreen(
                             tint = Color.Unspecified,
                             modifier = Modifier
                                 .align(alignment = Alignment.BottomEnd)
-                                .clickable{ onProfileClicked() }
+                                .noRippleClickable{ onProfileClicked() }
                         )
                     }
                     Spacer(modifier = Modifier.weight(1f))

--- a/feature/profile/src/main/java/com/acon/acon/feature/profile/composable/screen/profileMod/composable/ProfileModScreen.kt
+++ b/feature/profile/src/main/java/com/acon/acon/feature/profile/composable/screen/profileMod/composable/ProfileModScreen.kt
@@ -61,6 +61,7 @@ import com.acon.acon.feature.profile.composable.screen.profileMod.NicknameStatus
 import com.acon.acon.feature.profile.composable.screen.profileMod.ProfileModSideEffect
 import com.acon.acon.feature.profile.composable.screen.profileMod.ProfileModState
 import com.acon.acon.feature.profile.composable.screen.profileMod.ProfileModViewModel
+import com.acon.acon.feature.profile.composable.screen.profileMod.ProfileUpdateResult
 import org.orbitmvi.orbit.compose.collectAsState
 
 @Composable
@@ -68,7 +69,8 @@ fun ProfileModScreenContainer(
     modifier: Modifier = Modifier,
     viewModel: ProfileModViewModel = hiltViewModel(),
     selectedPhotoId: String = "",
-    onNavigateToProfile: () -> Unit = {},
+    backToProfile: () -> Unit = {},
+    onNavigateToProfile: (ProfileUpdateResult) -> Unit = { }, // 이건 수정 성공/실패 값을 갖고 넘기는 함수.
     onNavigateToAreaVerification: () -> Unit = {},
     onNavigateToCustomGallery: () -> Unit = {},
 ) {
@@ -91,7 +93,7 @@ fun ProfileModScreenContainer(
                     context.startActivity(intent)
                 }
                 is ProfileModSideEffect.NavigateBack -> {
-                    onNavigateToProfile()
+                    backToProfile()
                 }
                 is ProfileModSideEffect.NavigateToCustomGallery -> {
                     onNavigateToCustomGallery()
@@ -100,6 +102,12 @@ fun ProfileModScreenContainer(
                     selectedPhotoId.let {
                         viewModel.updateProfileImage(selectedPhotoId)
                     }
+                }
+                is ProfileModSideEffect.NavigateToProfileSuccess -> {
+                    onNavigateToProfile(ProfileUpdateResult.SUCCESS)
+                }
+                is ProfileModSideEffect.NavigateToProfileFailed -> {
+                    onNavigateToProfile(ProfileUpdateResult.FAILURE)
                 }
             }
         }
@@ -129,7 +137,7 @@ fun ProfileModScreenContainer(
                 viewModel.hideDialog()
             },
             onClickLeft = { // 나가기 (프로필 뷰로 이동)
-                onNavigateToProfile()
+                backToProfile()
             },
             onClickRight = { // 계속 작성하기
                 viewModel.hideDialog()

--- a/feature/profile/src/main/java/com/acon/acon/feature/profile/composable/screen/profileMod/composable/ProfileModScreen.kt
+++ b/feature/profile/src/main/java/com/acon/acon/feature/profile/composable/screen/profileMod/composable/ProfileModScreen.kt
@@ -71,7 +71,6 @@ fun ProfileModScreenContainer(
     selectedPhotoId: String = "",
     backToProfile: () -> Unit = {},
     onNavigateToProfile: (ProfileUpdateResult) -> Unit = { }, // 이건 수정 성공/실패 값을 갖고 넘기는 함수.
-    onNavigateToAreaVerification: () -> Unit = {},
     onNavigateToCustomGallery: () -> Unit = {},
 ) {
     val state = viewModel.collectAsState().value
@@ -128,7 +127,7 @@ fun ProfileModScreenContainer(
         )
     }
 
-    if (state.showDialog) {
+    if (state.showExitDialog) {
         AconTwoButtonDialog(
             title = stringResource(R.string.profile_mod_alert_title),
             content = stringResource(R.string.profile_mod_alert_description),
@@ -136,33 +135,13 @@ fun ProfileModScreenContainer(
             rightButtonContent = stringResource(R.string.profile_mod_alert_right_btn),
             contentImage = 0,
             onDismissRequest = {
-                viewModel.hideDialog()
+                viewModel.hideExitDialog()
             },
             onClickLeft = { // 나가기 (프로필 뷰로 이동)
                 backToProfile()
             },
             onClickRight = { // 계속 작성하기
-                viewModel.hideDialog()
-            },
-            isImageEnabled = false
-        )
-    }
-
-    if (state.showAreaDeleteDialog) {
-        AconTwoButtonDialog(
-            title = stringResource(R.string.delete_area_alert_title, state.selectedArea ?: "이 동네"),
-            content = "",
-            leftButtonContent = stringResource(R.string.delete_area_alert_left_btn),
-            rightButtonContent = stringResource(R.string.delete_area_alert_right_btn),
-            contentImage = 0,
-            onDismissRequest = {
-                viewModel.hideAreaDeleteDialog()
-            },
-            onClickLeft = {
-                viewModel.hideAreaDeleteDialog()
-            },
-            onClickRight = {
-                state.selectedArea?.let { viewModel.removeVerifiedArea(it) }
+                viewModel.hideExitDialog()
             },
             isImageEnabled = false
         )
@@ -196,10 +175,8 @@ fun ProfileModScreenContainer(
         onNicknameChanged = viewModel::onNicknameChanged,
         onBirthdayChanged = viewModel::onBirthdayChanged,
         onFocusChanged = viewModel::onFocusChanged,
-        onBackClicked = viewModel::showDialog,
+        onBackClicked = viewModel::showExitDialog,
         onSaveClicked = viewModel::getPreSignedUrl,
-        onNavigateToAreaVerification = onNavigateToAreaVerification,
-        onRemoveArea = viewModel::showAreaDeleteDialog,
         onProfileClicked = viewModel::showProfileEditDialog,
     )
 }
@@ -213,8 +190,6 @@ fun ProfileModScreen(
     onFocusChanged: (Boolean) -> Unit = {},
     onBackClicked: () -> Unit,
     onSaveClicked: () -> Unit,
-    onNavigateToAreaVerification: () -> Unit,
-    onRemoveArea: (String) -> Unit = {},
     onProfileClicked: () -> Unit = {},
 ) {
     val focusManager = LocalFocusManager.current
@@ -391,26 +366,6 @@ fun ProfileModScreen(
                     }
                 }
 
-                Column(
-                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 15.dp),
-                ){
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.Start
-                    ){
-                        Text(text = "인증 동네", style = AconTheme.typography.head8_16_sb, color = AconTheme.color.White)
-                        Spacer(modifier = Modifier.width(4.dp))
-                        Text(text = "*", style = AconTheme.typography.head8_16_sb, color = AconTheme.color.Main_org1)
-                    }
-                    Spacer(modifier = Modifier.height(12.dp))
-                    VerifiedAreaChip(
-                        modifier = Modifier,
-                        areaList = state.verifiedAreaList,
-                        onAddArea = { onNavigateToAreaVerification() },
-                        onRemoveArea = onRemoveArea ,
-                        errorMessage = "로컬도토리를 위해 최소 1개의 동네를 인증해주세요"
-                    )
-                }
             }
         }
 
@@ -454,7 +409,5 @@ private fun ProfileModScreenPreview() {
         onFocusChanged = {},
         onBackClicked = {},
         onSaveClicked = {},
-        onNavigateToAreaVerification = {},
-        onRemoveArea = {}
     )
 }


### PR DESCRIPTION
## *🧨 Issue*
- closed #20 

## *💻 Work Description*
### Url 관련

- [x]  닉네임 유효성 검사, 프로필 수정 API 배포되면 Success 날아오는지 확인하기
- [x]  온보딩 다시하기 API 연결

### UI 관련 버그 (심각한 것 순)..

- [x]  지금 로그인한 사용자 정보 fetch해서, 수정 페이지 들어오면 그 값들 최초에 로드되어 있도록 하기
    - [x]  fetchInfo() 받아오기, Image도 로드
    - [x]  fetchInfo() 한 상태에서 닉네임 카운트, Validation , 생년월일 상태 업데이트하기
- [x]  프사 선택하고 popUp해서 돌아오면 state값 다 날아가있음. 유지되도록 변경
- [x]  사용자 닉네임 한글 섞어서 치는 경우, 16자 넘으면 안쳐지게 막는 게 안됐던 버그 해결
- [ ]  Invalid 문자열 치면 입력 끝날때까지 안기다리고 바로 에러메시지 뜸.
- [x]  문자열 포커스 안 잡혔을 때도 흰색 글씨로 보이게 하기 (placeholder은 gray)

- [x]  인증동네 컴포넌트 없애기
- [x]  noRippleClick 적용하기
    - [x]  앨범에서 사진 선택 다이얼로그
    - [x]  기본 이미지로 선택 → 하고 자동으로 모달시트 내려가게 처리
    - [x]  이미 사용 중인 닉네임입니다 분기처리

## *📸 Screenshot*
-

## *💭 To Reviewers*
-
