### PR TITLE
[Fix/#22] API 엔드포인트 수정사항 반영 & 다이얼로그 외부 클릭 시 닫힘 막기

### DIFF
--- a/core/designsystem/src/main/java/com/acon/acon/core/designsystem/component/dialog/AconDialog.kt
+++ b/core/designsystem/src/main/java/com/acon/acon/core/designsystem/component/dialog/AconDialog.kt
@@ -2,6 +2,7 @@ package com.acon.acon.core.designsystem.component.dialog
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 
 @Composable
 fun AconDialog(
@@ -9,7 +10,11 @@ fun AconDialog(
     content: @Composable () -> Unit,
 ) {
     Dialog(
-        onDismissRequest = onDismissRequest
+        onDismissRequest = onDismissRequest,
+        properties = DialogProperties(
+            dismissOnBackPress = false,
+            dismissOnClickOutside = false
+        )
     ) {
         content()
     }

--- a/data/src/main/kotlin/com/acon/acon/data/remote/AreaVerificationApi.kt
+++ b/data/src/main/kotlin/com/acon/acon/data/remote/AreaVerificationApi.kt
@@ -6,7 +6,7 @@ import retrofit2.http.Body
 import retrofit2.http.POST
 
 interface AreaVerificationApi {
-    @POST("/api/v1/member/area")
+    @POST("/api/v1/members/verified-areas")
     suspend fun verifyArea(
         @Body request: AreaVerificationRequest
     ): AreaVerificationResponse

--- a/data/src/main/kotlin/com/acon/acon/data/remote/SpotApi.kt
+++ b/data/src/main/kotlin/com/acon/acon/data/remote/SpotApi.kt
@@ -17,7 +17,7 @@ interface SpotApi {
         @Body request: SpotListRequest
     ): SpotListResponse
 
-    @POST("/api/v1/member/guided-spot")
+    @POST("/api/v1/members/guided-spots")
     suspend fun fetchRecentNavigationLocation(
         @Body request: RecentNavigationLocationRequest
     )

--- a/data/src/main/kotlin/com/acon/acon/data/remote/SpotApi.kt
+++ b/data/src/main/kotlin/com/acon/acon/data/remote/SpotApi.kt
@@ -27,7 +27,7 @@ interface SpotApi {
         @Path ("spotId") spotId: Long
     ): SpotDetailInfoResponse
 
-    @GET("/api/v1/spot/{spotId}/menus")
+    @GET("/api/v1/spots/{spotId}/menus")
     suspend fun getSpotMenuList(
         @Path ("spotId") spotId: Long
     ): SpotDetailMenuListResponse

--- a/data/src/main/kotlin/com/acon/acon/data/remote/SpotApi.kt
+++ b/data/src/main/kotlin/com/acon/acon/data/remote/SpotApi.kt
@@ -22,7 +22,7 @@ interface SpotApi {
         @Body request: RecentNavigationLocationRequest
     )
 
-    @GET("/api/v1/spot/{spotId}")
+    @GET("/api/v1/spots/{spotId}")
     suspend fun getSpotDetailInfo(
         @Path ("spotId") spotId: Long
     ): SpotDetailInfoResponse

--- a/data/src/main/kotlin/com/acon/acon/data/remote/UploadApi.kt
+++ b/data/src/main/kotlin/com/acon/acon/data/remote/UploadApi.kt
@@ -24,7 +24,7 @@ interface UploadApi {
         @Query("longitude") longitude: Double
     ): UploadGetSuggestionsResponse
 
-    @GET("/api/v1/spot/verify")
+    @GET("/api/v1/spots/verify")
     suspend fun getVerifySpotLocation(
         @Query("spotId") spotId: Long,
         @Query("latitude") latitude: Double,

--- a/data/src/main/kotlin/com/acon/acon/data/remote/UploadApi.kt
+++ b/data/src/main/kotlin/com/acon/acon/data/remote/UploadApi.kt
@@ -12,7 +12,7 @@ import retrofit2.http.POST
 import retrofit2.http.Query
 
 interface UploadApi {
-    @GET("/api/v1/member/acorn")
+    @GET("/api/v1/members/acorn")
     suspend fun getDotoriCount(): UploadGetDotoriResponse
 
     @GET("/api/v1/spots/search")

--- a/data/src/main/kotlin/com/acon/acon/data/remote/UploadApi.kt
+++ b/data/src/main/kotlin/com/acon/acon/data/remote/UploadApi.kt
@@ -31,7 +31,7 @@ interface UploadApi {
         @Query("longitude") longitude: Double
     ): UploadGetSpotVerifyResponse
 
-    @POST("/api/v1/review")
+    @POST("/api/v1/reviews")
     @Headers("Content-Type: application/json")
     suspend fun uploadPostReview(
         @Body request: ReviewRequest


### PR DESCRIPTION
## *🧨 Issue*
- closed #22 

## *💻 Work Description*
-  엔드포인트 변경사항 반영
- oneButtonDialog, twoButtonDialog에 dismissOnBackPress = false, dismissOnClickOutside = false 처리

## *📸 Screenshot*
-

## *💭 To Reviewers*
-
