### PR TITLE
[Feat/#25] 법정동 조회 API

### DIFF
--- a/data/src/main/kotlin/com/acon/acon/data/datasource/remote/SpotRemoteDataSource.kt
+++ b/data/src/main/kotlin/com/acon/acon/data/datasource/remote/SpotRemoteDataSource.kt
@@ -5,6 +5,7 @@ import com.acon.acon.data.dto.request.SpotListRequest
 import com.acon.acon.data.dto.response.SpotDetailInfoResponse
 import com.acon.acon.data.dto.response.SpotDetailMenuListResponse
 import com.acon.acon.data.dto.response.SpotListResponse
+import com.acon.acon.data.dto.response.area.LegalAreaResponse
 import com.acon.acon.data.remote.SpotApi
 import javax.inject.Inject
 
@@ -26,5 +27,9 @@ class SpotRemoteDataSource @Inject constructor(
 
     suspend fun getSpotMenuList(spotId: Long): SpotDetailMenuListResponse {
         return spotApi.getSpotMenuList(spotId)
+    }
+
+    suspend fun getLegalDong(latitude: Double, longitude: Double): LegalAreaResponse {
+        return spotApi.getLegalDong(latitude, longitude)
     }
 }

--- a/data/src/main/kotlin/com/acon/acon/data/datasource/remote/TokenRemoteDataSource.kt
+++ b/data/src/main/kotlin/com/acon/acon/data/datasource/remote/TokenRemoteDataSource.kt
@@ -12,7 +12,7 @@ import androidx.credentials.exceptions.NoCredentialException
 import com.acon.acon.data.BuildConfig
 import com.acon.acon.data.error.ErrorMessages
 import com.acon.acon.domain.error.user.CredentialException
-import com.google.android.libraries.identity.googleid.GetGoogleIdOption
+import com.google.android.libraries.identity.googleid.GetSignInWithGoogleOption
 import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
 import com.google.android.libraries.identity.googleid.GoogleIdTokenParsingException
 import dagger.hilt.android.qualifiers.ActivityContext
@@ -30,13 +30,9 @@ class TokenRemoteDataSource @Inject constructor(
     private val digest = md.digest(bytes)
     private val hashedNonce = digest.fold("") { str, it -> str + "%02x".format(it) }
 
-    private val googleIdOption: GetGoogleIdOption by lazy {
-        GetGoogleIdOption.Builder()
-            .setFilterByAuthorizedAccounts(false)
-            .setAutoSelectEnabled(false)
-            .setServerClientId(BuildConfig.GOOGLE_CLIENT_ID)
+    private val googleIdOption: GetSignInWithGoogleOption =
+        GetSignInWithGoogleOption.Builder(BuildConfig.GOOGLE_CLIENT_ID)
             .build()
-    }
 
     private val credentialManager: CredentialManager by lazy {
         CredentialManager.create(context)

--- a/data/src/main/kotlin/com/acon/acon/data/dto/response/area/LegalAreaResponse.kt
+++ b/data/src/main/kotlin/com/acon/acon/data/dto/response/area/LegalAreaResponse.kt
@@ -1,0 +1,14 @@
+package com.acon.acon.data.dto.response.area
+
+import com.acon.acon.domain.model.area.LegalArea
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class LegalAreaResponse(
+    @SerialName("area") val area: String
+) {
+    fun toLegalArea() = LegalArea(
+        area = area
+    )
+}

--- a/data/src/main/kotlin/com/acon/acon/data/remote/SpotApi.kt
+++ b/data/src/main/kotlin/com/acon/acon/data/remote/SpotApi.kt
@@ -5,10 +5,12 @@ import com.acon.acon.data.dto.request.SpotListRequest
 import com.acon.acon.data.dto.response.SpotDetailInfoResponse
 import com.acon.acon.data.dto.response.SpotDetailMenuListResponse
 import com.acon.acon.data.dto.response.SpotListResponse
+import com.acon.acon.data.dto.response.area.LegalAreaResponse
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.POST
 import retrofit2.http.Path
+import retrofit2.http.Query
 
 interface SpotApi {
 
@@ -31,4 +33,10 @@ interface SpotApi {
     suspend fun getSpotMenuList(
         @Path ("spotId") spotId: Long
     ): SpotDetailMenuListResponse
+
+    @GET("api/v1/area")
+    suspend fun getLegalDong(
+        @Query("latitude") latitude: Double,
+        @Query("longitude") longitude: Double
+    ) : LegalAreaResponse
 }

--- a/data/src/main/kotlin/com/acon/acon/data/repository/AreaVerificationRepositoryImpl.kt
+++ b/data/src/main/kotlin/com/acon/acon/data/repository/AreaVerificationRepositoryImpl.kt
@@ -14,7 +14,7 @@ class AreaVerificationRepositoryImpl @Inject constructor(
    override suspend fun verifyArea(
        latitude: Double,
        longitude: Double
-   ): Result<Area> = runCatchingWith {
+   ): Result<Area> = runCatchingWith() {
        remoteDataSource.verifyArea(
            latitude = latitude,
            longitude = longitude

--- a/data/src/main/kotlin/com/acon/acon/data/repository/SpotRepositoryImpl.kt
+++ b/data/src/main/kotlin/com/acon/acon/data/repository/SpotRepositoryImpl.kt
@@ -6,10 +6,12 @@ import com.acon.acon.data.dto.request.FilterListRequest
 import com.acon.acon.data.dto.request.RecentNavigationLocationRequest
 import com.acon.acon.data.dto.request.SpotListRequest
 import com.acon.acon.data.error.runCatchingWith
+import com.acon.acon.domain.error.area.GetLegalDongError
 import com.acon.acon.domain.error.spot.FetchRecentNavigationLocationError
 import com.acon.acon.domain.error.spot.FetchSpotListError
 import com.acon.acon.domain.error.spot.GetSpotDetailInfoError
 import com.acon.acon.domain.error.spot.GetSpotMenuListError
+import com.acon.acon.domain.model.area.LegalArea
 import com.acon.acon.domain.model.spot.Condition
 import com.acon.acon.domain.model.spot.Spot
 import com.acon.acon.domain.model.spot.SpotDetailInfo
@@ -68,6 +70,12 @@ class SpotRepositoryImpl @Inject constructor(
     ): Result<List<SpotDetailMenu>> {
         return runCatchingWith(*GetSpotMenuListError.createErrorInstances()) {
             spotRemoteDataSource.getSpotMenuList(spotId).menuList.map { it.toSpotDetailMenu() }
+        }
+    }
+
+    override suspend fun getLegalDong(latitude: Double, longitude: Double): Result<LegalArea> {
+        return runCatchingWith(*GetLegalDongError.createErrorInstances()) {
+            spotRemoteDataSource.getLegalDong(latitude, longitude).toLegalArea()
         }
     }
 

--- a/data/src/main/kotlin/com/acon/acon/data/repository/UploadRepositoryImpl.kt
+++ b/data/src/main/kotlin/com/acon/acon/data/repository/UploadRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.acon.acon.data.repository
 
 import com.acon.acon.data.datasource.remote.UploadRemoteDataSource
 import com.acon.acon.data.error.runCatchingWith
+import com.acon.acon.domain.error.user.GetSuggestionsError
 import com.acon.acon.domain.model.upload.DotoriCount
 import com.acon.acon.domain.model.upload.KeyWord
 import com.acon.acon.domain.model.upload.SpotVerification
@@ -23,7 +24,7 @@ class UploadRepositoryImpl @Inject constructor(
     override suspend fun getSuggestions(
         latitude: Double,
         longitude: Double
-    ): Result<Suggestions> = runCatchingWith {
+    ): Result<Suggestions> = runCatchingWith(*GetSuggestionsError.createErrorInstances()) {
         uploadRemoteDataSource.getSuggestions(latitude, longitude).toSuggestions()
     }
 

--- a/data/src/main/kotlin/com/acon/acon/data/repository/UploadRepositoryImpl.kt
+++ b/data/src/main/kotlin/com/acon/acon/data/repository/UploadRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.acon.acon.data.repository
 
 import com.acon.acon.data.datasource.remote.UploadRemoteDataSource
 import com.acon.acon.data.error.runCatchingWith
+import com.acon.acon.domain.error.upload.GetVerifySpotLocationError
 import com.acon.acon.domain.error.user.GetSuggestionsError
 import com.acon.acon.domain.model.upload.DotoriCount
 import com.acon.acon.domain.model.upload.KeyWord
@@ -32,7 +33,7 @@ class UploadRepositoryImpl @Inject constructor(
         spotId: Long,
         latitude: Double,
         longitude: Double
-    ): Result<SpotVerification> = runCatchingWith {
+    ): Result<SpotVerification> = runCatchingWith(*GetVerifySpotLocationError.createErrorInstances()) {
         uploadRemoteDataSource.getVerifySpotLocation(
             spotId = spotId,
             latitude = latitude,

--- a/domain/src/main/java/com/acon/acon/domain/error/area/DeleteVerifiedAreaError.kt
+++ b/domain/src/main/java/com/acon/acon/domain/error/area/DeleteVerifiedAreaError.kt
@@ -2,7 +2,6 @@ package com.acon.acon.domain.error.area
 
 import com.acon.acon.domain.error.ErrorFactory
 import com.acon.acon.domain.error.RootError
-import com.acon.acon.domain.error.spot.FetchRecentNavigationLocationError.SpaceNotFoundError
 
 sealed class DeleteVerifiedAreaError : RootError() {
 
@@ -21,7 +20,9 @@ sealed class DeleteVerifiedAreaError : RootError() {
     companion object : ErrorFactory {
         override fun createErrorInstances(): Array<RootError> {
             return arrayOf(
-                SpaceNotFoundError(),
+                InvalidVerifiedArea(),
+                VerifiedAreaLimitViolation(),
+                VerifiedAreaNotFound()
             )
         }
     }

--- a/domain/src/main/java/com/acon/acon/domain/error/area/GetLegalDongError.kt
+++ b/domain/src/main/java/com/acon/acon/domain/error/area/GetLegalDongError.kt
@@ -1,0 +1,18 @@
+package com.acon.acon.domain.error.area
+
+import com.acon.acon.domain.error.ErrorFactory
+import com.acon.acon.domain.error.RootError
+
+sealed class GetLegalDongError : RootError() {
+    class OutOfServiceAreaError : GetLegalDongError() {
+        override val code: Int = 40405
+    }
+
+    companion object : ErrorFactory {
+        override fun createErrorInstances(): Array<RootError> {
+            return arrayOf(
+                OutOfServiceAreaError()
+            )
+        }
+    }
+}

--- a/domain/src/main/java/com/acon/acon/domain/error/area/PostVerifyAreaError.kt
+++ b/domain/src/main/java/com/acon/acon/domain/error/area/PostVerifyAreaError.kt
@@ -1,0 +1,18 @@
+package com.acon.acon.domain.error.area
+
+import com.acon.acon.domain.error.ErrorFactory
+import com.acon.acon.domain.error.RootError
+
+sealed class PostVerifyAreaError : RootError() {
+    class OutOfServiceAreaError : PostVerifyAreaError() {
+        override val code: Int = 40405
+    }
+
+    companion object : ErrorFactory {
+        override fun createErrorInstances(): Array<RootError> {
+            return arrayOf(
+                OutOfServiceAreaError(),
+            )
+        }
+    }
+}

--- a/domain/src/main/java/com/acon/acon/domain/error/spot/FetchSpotListError.kt
+++ b/domain/src/main/java/com/acon/acon/domain/error/spot/FetchSpotListError.kt
@@ -21,6 +21,10 @@ sealed class FetchSpotListError : RootError() {
         override val code: Int = 40022
     }
 
+    class OutOfServiceAreaError : FetchSpotListError() {
+        override val code: Int = 40405
+    }
+
     companion object : ErrorFactory {
         override fun createErrorInstances(): Array<RootError> {
             return arrayOf(
@@ -28,7 +32,8 @@ sealed class FetchSpotListError : RootError() {
                 InvalidCategory(),
                 InvalidOption(),
                 NonMatchingSpotTypeAndCategory(),
-                NonMatchingCategoryAndOption()
+                NonMatchingCategoryAndOption(),
+                OutOfServiceAreaError()
             )
         }
     }

--- a/domain/src/main/java/com/acon/acon/domain/error/upload/GetVerifySpotLocationError.kt
+++ b/domain/src/main/java/com/acon/acon/domain/error/upload/GetVerifySpotLocationError.kt
@@ -1,0 +1,18 @@
+package com.acon.acon.domain.error.upload
+
+import com.acon.acon.domain.error.ErrorFactory
+import com.acon.acon.domain.error.RootError
+
+sealed class GetVerifySpotLocationError : RootError() {
+    class OutOfServiceAreaError : GetVerifySpotLocationError() {
+        override val code: Int = 40405
+    }
+
+    companion object : ErrorFactory {
+        override fun createErrorInstances(): Array<RootError> {
+            return arrayOf(
+                OutOfServiceAreaError()
+            )
+        }
+    }
+}

--- a/domain/src/main/java/com/acon/acon/domain/error/user/GetSuggestionsError.kt
+++ b/domain/src/main/java/com/acon/acon/domain/error/user/GetSuggestionsError.kt
@@ -1,0 +1,18 @@
+package com.acon.acon.domain.error.user
+
+import com.acon.acon.domain.error.ErrorFactory
+import com.acon.acon.domain.error.RootError
+
+sealed class GetSuggestionsError : RootError() {
+    class OutOfServiceAreaError : GetSuggestionsError() {
+        override val code: Int = 40405
+    }
+
+    companion object : ErrorFactory {
+        override fun createErrorInstances(): Array<RootError> {
+            return arrayOf(
+                OutOfServiceAreaError()
+            )
+        }
+    }
+}

--- a/domain/src/main/java/com/acon/acon/domain/model/area/LegalArea.kt
+++ b/domain/src/main/java/com/acon/acon/domain/model/area/LegalArea.kt
@@ -1,0 +1,5 @@
+package com.acon.acon.domain.model.area
+
+data class LegalArea(
+    val area: String
+)

--- a/domain/src/main/java/com/acon/acon/domain/repository/SpotRepository.kt
+++ b/domain/src/main/java/com/acon/acon/domain/repository/SpotRepository.kt
@@ -1,5 +1,6 @@
 package com.acon.acon.domain.repository
 
+import com.acon.acon.domain.model.area.LegalArea
 import com.acon.acon.domain.model.spot.Condition
 import com.acon.acon.domain.model.spot.Spot
 import com.acon.acon.domain.model.spot.SpotDetailInfo
@@ -25,4 +26,8 @@ interface SpotRepository {
         spotId: Long,
     ): Result<List<SpotDetailMenu>>
 
+    suspend fun getLegalDong(
+        latitude: Double,
+        longitude: Double,
+    ): Result<LegalArea>
 }

--- a/feature/spot/src/main/java/com/acon/acon/feature/spot/screen/spotlist/SpotListViewModel.kt
+++ b/feature/spot/src/main/java/com/acon/acon/feature/spot/screen/spotlist/SpotListViewModel.kt
@@ -7,7 +7,6 @@ import com.acon.acon.core.utils.feature.base.BaseContainerHost
 import com.acon.acon.domain.error.user.CredentialException
 import com.acon.acon.domain.model.spot.Condition
 import com.acon.acon.domain.model.spot.Spot
-import com.acon.acon.domain.repository.MapRepository
 import com.acon.acon.domain.repository.SocialRepository
 import com.acon.acon.domain.repository.SpotRepository
 import com.acon.acon.domain.repository.TokenRepository
@@ -23,8 +22,7 @@ import kotlin.coroutines.cancellation.CancellationException
 @HiltViewModel
 class SpotListViewModel @Inject constructor(
     private val tokenRepository: TokenRepository,
-    private val spotRepository: SpotRepository,
-    private val mapRepository: MapRepository,
+    private val spotRepository: SpotRepository
 ) : BaseContainerHost<SpotListUiState, SpotListSideEffect>() {
 
     override val container =
@@ -70,7 +68,7 @@ class SpotListViewModel @Inject constructor(
 
     fun fetchInitialSpots(location: Location) = intent {
         val legalAddressNameDeferred = viewModelScope.async {
-            mapRepository.fetchLegalAddressName(
+            spotRepository.getLegalDong(
                 latitude = location.latitude,
                 longitude = location.longitude
             ).getOrNull()
@@ -97,21 +95,21 @@ class SpotListViewModel @Inject constructor(
                         (state as? SpotListUiState.Success)?.copy(
                             spotList = it,
                             isRefreshing = false,
-                            legalAddressName = legalAddressName
+                            legalAddressName = legalAddressName.area
                         ) ?: SpotListUiState.Success(
                             spotList = it,
-                            legalAddressName = legalAddressName,
+                            legalAddressName = legalAddressName.area,
                             isRefreshing = false
                         )
                     } else {
                         (state as? SpotListUiState.Guest)?.copy(
                             spotList = it,
                             isRefreshing = false,
-                            legalAddressName = legalAddressName,
+                            legalAddressName = legalAddressName.area,
                             showLoginBottomSheet = (state as? SpotListUiState.Guest)?.showLoginBottomSheet ?: false
                         ) ?: SpotListUiState.Guest(
                             spotList = it,
-                            legalAddressName = legalAddressName,
+                            legalAddressName = legalAddressName.area,
                             isRefreshing = false,
                             showLoginBottomSheet = false
                         )
@@ -123,7 +121,7 @@ class SpotListViewModel @Inject constructor(
 
     private fun onLocationReady(newLocation: Location) = blockingIntent {
         val legalAddressNameDeferred = viewModelScope.async {
-            mapRepository.fetchLegalAddressName(
+            spotRepository.getLegalDong(
                 latitude = newLocation.latitude,
                 longitude = newLocation.longitude
             ).getOrNull()
@@ -150,21 +148,21 @@ class SpotListViewModel @Inject constructor(
                         (state as? SpotListUiState.Success)?.copy(
                             spotList = it,
                             isRefreshing = false,
-                            legalAddressName = legalAddressName
+                            legalAddressName = legalAddressName.area
                         ) ?: SpotListUiState.Success(
                             spotList = it,
-                            legalAddressName = legalAddressName,
+                            legalAddressName = legalAddressName.area,
                             isRefreshing = false
                         )
                     } else {
                         (state as? SpotListUiState.Guest)?.copy(
                             spotList = it,
                             isRefreshing = false,
-                            legalAddressName = legalAddressName,
+                            legalAddressName = legalAddressName.area,
                             showLoginBottomSheet = (state as? SpotListUiState.Guest)?.showLoginBottomSheet ?: false
                         ) ?: SpotListUiState.Guest(
                             spotList = it,
-                            legalAddressName = legalAddressName,
+                            legalAddressName = legalAddressName.area,
                             isRefreshing = false,
                             showLoginBottomSheet = false
                         )


### PR DESCRIPTION
## *🧨 Issue*
- closed #25 

## *💻 Work Description*
- 법정동 조회 API 추가 및 연결 
- 홈 화면의 동네이름 조회 시 직접 네이버 API 호출하는 방식에서 법정동 조회 API로 수행하도록 수정
- 위치(좌표)를 활용하는 API들에 대해 40405에러 추가
  - 동네 인증 API (POST)
  - 위치 기반 장소 추천 API (POST)
  - 리뷰 작성시 위치 인증 API (GET)
  - 추천 검색어 조회 API (GET)
