### PR TITLE
[Feat/#28] 위/경도 서비스 제공 지역 밖일 때 (40405) UI, 다이얼로그 표시

### DIFF
--- a/app/src/main/java/com/acon/acon/navigation/nested/AreaVerificationNavigation.kt
+++ b/app/src/main/java/com/acon/acon/navigation/nested/AreaVerificationNavigation.kt
@@ -70,7 +70,7 @@ fun NavGraphBuilder.areaVerificationNavigation(
                 onNavigateToNext = {
                     if (route.route == "settings") {
                         navController.navigate(SettingsRoute.LocalVerification) {
-                            popUpTo(AreaVerificationRoute.Graph) {
+                            popUpTo(SettingsRoute.LocalVerification) {
                                 inclusive = true
                             }
                         }

--- a/app/src/main/java/com/acon/acon/navigation/nested/SettingsNavigation.kt
+++ b/app/src/main/java/com/acon/acon/navigation/nested/SettingsNavigation.kt
@@ -58,7 +58,15 @@ internal fun NavGraphBuilder.settingsNavigation(
             LocalVerificationScreenContainer(
                 modifier = Modifier.fillMaxSize(),
                 navigateToSettingsScreen = { navController.popBackStack() },
-                navigateToAreaVerification = {
+                navigateToAreaVerificationToAdd = {
+                    navController.navigate(
+                        AreaVerificationRoute.RequireAreaVerification(
+                            route = "settings",
+                            isEdit = false
+                        )
+                    )
+                },
+                navigateToAreaVerificationToEdit = {
                     navController.navigate(
                         AreaVerificationRoute.RequireAreaVerification(
                             route = "settings",

--- a/core/designsystem/src/main/java/com/acon/acon/core/designsystem/component/dialog/AconOneButtonDialog.kt
+++ b/core/designsystem/src/main/java/com/acon/acon/core/designsystem/component/dialog/AconOneButtonDialog.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -18,6 +19,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.acon.acon.core.designsystem.component.button.AconFilledMediumButton
 import com.acon.acon.core.designsystem.R
@@ -29,16 +31,18 @@ fun AconOneButtonDialog(
     title: String,
     content: String,
     buttonContent: String,
-    @DrawableRes contentImage: Int? = null,
     onDismissRequest: () -> Unit,
     onClickConfirm: () -> Unit,
+    modifier: Modifier = Modifier,
+    imageSize: Dp? = null,
+    @DrawableRes contentImage: Int? = null,
     isImageEnabled: Boolean = false,
 ) {
     AconDialog(
         onDismissRequest = onDismissRequest
     ) {
         Column(
-            modifier = Modifier
+            modifier = modifier
                 .fillMaxWidth()
                 .clip(RoundedCornerShape(8.dp))
                 .background(AconTheme.color.Gray8)
@@ -48,7 +52,12 @@ fun AconOneButtonDialog(
             if(isImageEnabled && contentImage != null) {
                 Image(
                     imageVector = ImageVector.vectorResource(contentImage),
-                    contentDescription = ""
+                    contentDescription = "",
+                    modifier = if (imageSize != null) {
+                        Modifier.size(imageSize)
+                    } else {
+                        Modifier
+                    }
                 )
                 Spacer(modifier = Modifier.height(16.dp))
             }

--- a/feature/profile/src/main/java/com/acon/acon/feature/profile/composable/screen/profile/ProfileViewModel.kt
+++ b/feature/profile/src/main/java/com/acon/acon/feature/profile/composable/screen/profile/ProfileViewModel.kt
@@ -1,6 +1,5 @@
 package com.acon.acon.feature.profile.composable.screen.profile
 
-import android.util.Log
 import androidx.compose.runtime.Immutable
 import com.acon.acon.core.utils.feature.base.BaseContainerHost
 import com.acon.acon.domain.model.profile.VerifiedArea
@@ -23,12 +22,9 @@ class ProfileViewModel @Inject constructor(
     override val container =
         container<ProfileUiState, ProfileUiSideEffect>(ProfileUiState.Loading) {
             val isLogin = tokenRepository.getIsLogin().getOrElse { false }
-            Log.d("로그","isLogin $isLogin")
             if (isLogin) {
-                Log.d("로그","fetchUserProfileInfo")
                 fetchUserProfileInfo()
             } else {
-                Log.d("로그","GUEST")
                 reduce { ProfileUiState.GUEST() }
             }
         }
@@ -61,8 +57,6 @@ class ProfileViewModel @Inject constructor(
     }
 
      fun fetchUserProfileInfo() = intent {
-         Log.d("로그","profileRepository.fetchProfile()")
-
         profileRepository.fetchProfile()
             .onSuccess { profile ->
                 reduce {

--- a/feature/profile/src/main/java/com/acon/acon/feature/profile/composable/screen/profile/composable/ProfileScreen.kt
+++ b/feature/profile/src/main/java/com/acon/acon/feature/profile/composable/screen/profile/composable/ProfileScreen.kt
@@ -162,7 +162,12 @@ fun ProfileScreen(
                     )
                     ProfileInfo(
                         profileInfoType = ProfileInfoType.AREA,
-                        area = state.verifiedArea[0].name,
+                        area = if(state.verifiedArea.size > 1) {
+                            "${state.verifiedArea[0].name} 외${state.verifiedArea.size - 1}"
+                        }
+                        else {
+                            state.verifiedArea[0].name
+                        },
                         modifier = Modifier.weight(1f)
                     )
                 }

--- a/feature/settings/src/main/java/com/acon/acon/feature/settings/screen/composable/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/acon/acon/feature/settings/screen/composable/SettingsScreen.kt
@@ -1,5 +1,6 @@
 package com.acon.acon.feature.settings.screen.composable
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -40,6 +41,9 @@ fun SettingsScreen(
     onSignOut: () -> Unit = {},
     onDeleteAccountScreen: () -> Unit = {},
 ) {
+    BackHandler {
+        navigateBack()
+    }
 
     when(state) {
         is SettingsUiState.Default -> {

--- a/feature/settings/src/main/java/com/acon/acon/feature/verification/screen/LocalVerificationViewModel.kt
+++ b/feature/settings/src/main/java/com/acon/acon/feature/verification/screen/LocalVerificationViewModel.kt
@@ -64,8 +64,12 @@ class LocalVerificationViewModel @Inject constructor(
         postSideEffect(LocalVerificationSideEffect.NavigateToSettingsScreen)
     }
 
-    fun onNavigateToAreaVerificationCheckInMap() = intent {
-        postSideEffect(LocalVerificationSideEffect.NavigateToAreaVerificationCheckInMap)
+    fun onNavigateToAreaVerificationAdd() = intent {
+        postSideEffect(LocalVerificationSideEffect.NavigateToAreaVerificationToAdd)
+    }
+
+    fun onNavigateToAreaVerificationEdit() = intent {
+        postSideEffect(LocalVerificationSideEffect.NavigateToAreaVerificationToEdit)
     }
 
 }
@@ -83,5 +87,6 @@ sealed interface LocalVerificationUiState {
 
 sealed interface LocalVerificationSideEffect {
     data object NavigateToSettingsScreen : LocalVerificationSideEffect
-    data object NavigateToAreaVerificationCheckInMap : LocalVerificationSideEffect
+    data object NavigateToAreaVerificationToAdd : LocalVerificationSideEffect
+    data object NavigateToAreaVerificationToEdit : LocalVerificationSideEffect
 }

--- a/feature/settings/src/main/java/com/acon/acon/feature/verification/screen/composable/LocalVerificationScreen.kt
+++ b/feature/settings/src/main/java/com/acon/acon/feature/verification/screen/composable/LocalVerificationScreen.kt
@@ -44,6 +44,7 @@ fun LocalVerificationScreen(
     maxLocalVerificationArea: Int = 5,
     onNavigateBack: () -> Unit = {},
     onclickAddArea: () -> Unit = {},
+    onclickEditArea: () -> Unit = {},
     onDeleteVerifiedAreaChip: (Long) -> Unit = {},
     onShowEditVerifiedAreaChipDialog: (Boolean) -> Unit = {},
     onShowDeleteVerifiedAreaChipDialog: (Boolean, Long) -> Unit = { _, _ -> }
@@ -61,7 +62,7 @@ fun LocalVerificationScreen(
                     rightButtonContent = stringResource(R.string.area_edit_dialog_right_btn),
                     onDismissRequest = { onShowEditVerifiedAreaChipDialog(false) },
                     onClickLeft = { onShowEditVerifiedAreaChipDialog(false) } ,
-                    onClickRight = onclickAddArea,
+                    onClickRight = onclickEditArea,
                 )
             }
 

--- a/feature/settings/src/main/java/com/acon/acon/feature/verification/screen/composable/LocalVerificationScreenContainer.kt
+++ b/feature/settings/src/main/java/com/acon/acon/feature/verification/screen/composable/LocalVerificationScreenContainer.kt
@@ -13,7 +13,8 @@ import org.orbitmvi.orbit.compose.collectSideEffect
 fun LocalVerificationScreenContainer(
     modifier: Modifier = Modifier,
     navigateToSettingsScreen: () -> Unit = {},
-    navigateToAreaVerification: () -> Unit = {},
+    navigateToAreaVerificationToAdd: () -> Unit = {},
+    navigateToAreaVerificationToEdit: () -> Unit = {},
     viewModel: LocalVerificationViewModel = hiltViewModel()
 ) {
     val state by viewModel.collectAsState()
@@ -22,7 +23,8 @@ fun LocalVerificationScreenContainer(
         state = state,
         modifier = modifier,
         onNavigateBack = viewModel::onNavigateToSettingsScreen,
-        onclickAddArea = viewModel::onNavigateToAreaVerificationCheckInMap,
+        onclickAddArea = viewModel::onNavigateToAreaVerificationAdd,
+        onclickEditArea = viewModel::onNavigateToAreaVerificationEdit,
         onDeleteVerifiedAreaChip = viewModel::deleteVerifiedArea,
         onShowEditVerifiedAreaChipDialog = viewModel::onShowEditVerifiedAreaChipDialog,
         onShowDeleteVerifiedAreaChipDialog = viewModel::onShowDeleteVerifiedAreaChipDialog,
@@ -31,7 +33,8 @@ fun LocalVerificationScreenContainer(
     viewModel.collectSideEffect {
         when(it) {
             is LocalVerificationSideEffect.NavigateToSettingsScreen -> navigateToSettingsScreen()
-            is LocalVerificationSideEffect.NavigateToAreaVerificationCheckInMap -> navigateToAreaVerification()
+            is LocalVerificationSideEffect.NavigateToAreaVerificationToAdd -> navigateToAreaVerificationToAdd()
+            is LocalVerificationSideEffect.NavigateToAreaVerificationToEdit -> navigateToAreaVerificationToEdit()
         }
     }
 

--- a/feature/spot/src/main/java/com/acon/acon/feature/spot/screen/spotlist/composable/EmptySpotListView.kt
+++ b/feature/spot/src/main/java/com/acon/acon/feature/spot/screen/spotlist/composable/EmptySpotListView.kt
@@ -29,7 +29,7 @@ fun EmptySpotListView(
         verticalArrangement = Arrangement.Center
     ) {
         Image(
-            imageVector = ImageVector.vectorResource(com.acon.acon.core.designsystem.R.drawable.ic_error_1_120),
+            imageVector = ImageVector.vectorResource(com.acon.acon.core.designsystem.R.drawable.ic_warning_acon_140),
             contentDescription = null
         )
         Text(

--- a/feature/spot/src/main/java/com/acon/acon/feature/spot/screen/spotlist/composable/SpotListScreen.kt
+++ b/feature/spot/src/main/java/com/acon/acon/feature/spot/screen/spotlist/composable/SpotListScreen.kt
@@ -2,6 +2,7 @@ package com.acon.acon.feature.spot.screen.spotlist.composable
 
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.SpringSpec
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.collectIsDraggedAsState
 import androidx.compose.foundation.layout.Arrangement
@@ -178,6 +179,7 @@ internal fun SpotListScreen(
                                     }
                             ) {
                                 if (isResultEmpty) {
+                                    Spacer(Modifier.height(100.dp))
                                     EmptySpotListView(modifier = Modifier.fillMaxSize())
                                 } else {
                                     Text(
@@ -202,23 +204,25 @@ internal fun SpotListScreen(
                                         if (spot !== state.spotList.last())
                                             Spacer(modifier = Modifier.height(12.dp))
                                     }
+
+                                    Column(
+                                        modifier = Modifier
+                                            .padding(top = 12.dp)
+                                            .fillMaxWidth()
+                                            .onSizeChanged { size ->
+                                                scrollableInvisibleHeightPx = size.height
+                                            },
+                                        horizontalAlignment = Alignment.CenterHorizontally
+                                    ) {
+                                        Text(
+                                            modifier = Modifier.padding(top = 38.dp, bottom = 50.dp),
+                                            text = stringResource(R.string.alert_max_spot_count),
+                                            style = AconTheme.typography.body2_14_reg,
+                                            color = AconTheme.color.Gray5
+                                        )
+                                    }
                                 }
-                                Column(
-                                    modifier = Modifier
-                                        .padding(top = 12.dp)
-                                        .fillMaxWidth()
-                                        .onSizeChanged { size ->
-                                            scrollableInvisibleHeightPx = size.height
-                                        },
-                                    horizontalAlignment = Alignment.CenterHorizontally
-                                ) {
-                                    Text(
-                                        modifier = Modifier.padding(top = 38.dp, bottom = 50.dp),
-                                        text = stringResource(R.string.alert_max_spot_count),
-                                        style = AconTheme.typography.body2_14_reg,
-                                        color = AconTheme.color.Gray5
-                                    )
-                                }
+
                             }
                         }
                         Column(
@@ -352,6 +356,7 @@ internal fun SpotListScreen(
                                     }
                             ) {
                                 if (isResultEmpty) {
+                                    Spacer(Modifier.height(100.dp))
                                     EmptySpotListView(modifier = Modifier.fillMaxSize())
                                 } else {
                                     Text(
@@ -425,7 +430,40 @@ internal fun SpotListScreen(
             }
 
             is SpotListUiState.LoadFailed -> {
-                // TODO : 로드 실패 뷰
+
+            }
+
+            is SpotListUiState.OutOfServiceArea -> {
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                ) {
+                    Text(
+                        text = stringResource(R.string.out_of_service_area_name),
+                        style = AconTheme.typography.head5_22_sb,
+                        color = AconTheme.color.White,
+                        modifier = Modifier
+                            .padding(start = 16.dp, top = 57.dp)
+                    )
+
+                    Spacer(Modifier.height(110.dp))
+                    Image(
+                        imageVector = ImageVector.vectorResource(com.acon.acon.core.designsystem.R.drawable.ic_warning_acon_140),
+                        contentDescription = stringResource(R.string.out_of_service_area_content_description),
+                        modifier = Modifier
+                            .align(Alignment.CenterHorizontally)
+                    )
+
+                    Spacer(Modifier.height(24.dp))
+                    Text(
+                        text = stringResource(R.string.out_of_service_area_content),
+                        style = AconTheme.typography.subtitle1_16_med,
+                        color = AconTheme.color.Gray4,
+                        modifier = Modifier
+                            .align(Alignment.CenterHorizontally)
+
+                    )
+                }
             }
         }
     }
@@ -443,6 +481,6 @@ private fun SpotListScreenPreview() {
 @Composable
 private fun SpotListLoadingScreenPreview() {
     SpotListScreen(
-        state = SpotListUiState.Loading
+        state = SpotListUiState.LoadFailed
     )
 }

--- a/feature/spot/src/main/res/values/strings.xml
+++ b/feature/spot/src/main/res/values/strings.xml
@@ -2,6 +2,11 @@
 <resources>
     <string name="signin_login_failed_toast">로그인에 실패했습니다.</string>
 
+    <!-- out of service area -->
+    <string name="out_of_service_area_name">서비스 불가지역</string>
+    <string name="out_of_service_area_content_description">서비스가 불가능한 지역에 있습니다.</string>
+    <string name="out_of_service_area_content">앗! 서비스 지원이 불가능한 지역에 있어요</string>
+
     <string name="spot_name">동네 이름</string>
     <string name="spot_recommendation_description">지금, 나에게 딱 맞는 공간들이에요</string>
     <string name="matching_rate">취향 일치율 %s%%</string>

--- a/feature/upload/build.gradle.kts
+++ b/feature/upload/build.gradle.kts
@@ -38,6 +38,12 @@ android {
 
 dependencies {
 
+    implementation(project(":domain"))
+    implementation(project(":core:common"))
+    implementation(project(":core:designsystem"))
+    implementation(project(":core:utils:feature"))
+    implementation(project(":core:map"))
+
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
     implementation(libs.material)
@@ -67,9 +73,4 @@ dependencies {
     implementation(libs.haze.materials)
 
     implementation(libs.kotlinx.immutable)
-
-    implementation(project(":domain"))
-
-    implementation(project(":core:designsystem"))
-    implementation(project(":core:map"))
 }

--- a/feature/upload/src/main/java/com/acon/acon/feature/upload/UploadState.kt
+++ b/feature/upload/src/main/java/com/acon/acon/feature/upload/UploadState.kt
@@ -19,5 +19,7 @@ data class UploadState(
     val isLocationVerified: Boolean = false,
     val locationVerificationResult: Boolean? = null,
     val showInsufficientDotoriSnackbar: Boolean = false,
-    val isLoading: Boolean = false
+    val isLoading: Boolean = false,
+    val showOutOfServiceDialog: Boolean = false,
+    val showLocationSearchBottomSheet: Boolean = false
 )

--- a/feature/upload/src/main/java/com/acon/acon/feature/upload/component/LocationSearchBottomSheet.kt
+++ b/feature/upload/src/main/java/com/acon/acon/feature/upload/component/LocationSearchBottomSheet.kt
@@ -94,7 +94,8 @@ fun LocationSearchBottomSheet(
                 showVerificationFailDialog = false
                 viewModel.onIntent(UploadIntent.ResetVerification)
             },
-            isImageEnabled = true
+            isImageEnabled = true,
+            modifier = Modifier.padding(horizontal = 32.dp)
         )
     }
 


### PR DESCRIPTION
## *🧨 Issue*
- closed #28 

## *💻 Work Description*
- 일부UI 및 컴포넌트 수정

- 버그 수정
  -  인증 동네 추가에서 항상 추가 후 삭제되도록 하는 문제 수정 (마지막 동네만 추가 후 삭제) 
  - 동네인증 지도뷰에서 인증 동네 추가 화면으로 돌아왔을 때 기존 인증 동네 추가 화면 스택이 남아있던 것 삭제 되도록 수정
  - 설정 화면에서 뒤로가기 시 프로필 화면 새로고침 되도록 수정
  
- 홈 화면에서 40405 에러 반환시 서비스 불가 지역 뷰 표시
- 업로드 화면에서 40405 에러 반환시 서비스 불가 지역 다이얼로그 표시


## *📸 Screenshot*
<!DOCTYPE html>
<html lang="ko">
<head>
    <meta charset="UTF-8">
    <meta name="viewport" content="width=device-width, initial-scale=1.0">
</head>

<body>
    <table>
        <thead>
            <tr>
                <th>홈 화면 (서비스 불가 지역)</th>
                <th>업로드 화면 (서비스 불가지역)</th>
            </tr>
        </thead>
        <tbody>
            <tr>
                <td><image src="https://github.com/user-attachments/assets/9123589c-a802-4017-a0e3-7a3710bef9fe" controls width="250"></video></td>
                <td><image src="https://github.com/user-attachments/assets/e90d9b69-5642-46b1-a827-11a1025a0641"controls width ="250"></video></td>
            </tr>
        </tbody>
    </table>
</body>
</html>

## *💭 To Reviewers*
-



