### PR TITLE
[Feat/#29] onboarding gps bug fix

### DIFF
--- a/app/src/main/java/com/acon/acon/navigation/nested/AreaVerificationNavigation.kt
+++ b/app/src/main/java/com/acon/acon/navigation/nested/AreaVerificationNavigation.kt
@@ -75,7 +75,9 @@ fun NavGraphBuilder.areaVerificationNavigation(
                             }
                         }
                     } else {
-                        navController.navigate(OnboardingRoute.Graph)
+                        navController.navigate(OnboardingRoute.Graph) {
+                            popUpTo(0) { inclusive = true }
+                        }
                     }
                 },
                 onBackClick = {

--- a/app/src/main/java/com/acon/acon/navigation/nested/OnboardingNavigation.kt
+++ b/app/src/main/java/com/acon/acon/navigation/nested/OnboardingNavigation.kt
@@ -34,13 +34,13 @@ internal fun NavGraphBuilder.onboardingNavigationNavigation(
                     navController.navigate(SpotRoute.SpotList)
                 },
                 cancelOnboarding = {
-                    if (fromSettings) { // 스택에 설정이 있는 경우, 즉 설정에서 온보딩으로 들어온 경우
+                    if (fromSettings) {
                         navController.navigate(SettingsRoute.Settings) {
                             popUpTo(SettingsRoute.Settings) {
                                 inclusive = false
                             }
                         }
-                    } else { // 그 이외, 최초 로그인 후 온보딩으로 들어온 경우에 뒤로가기를 누른 경우
+                    } else {
                         navController.popBackStack()
                     }
                 }

--- a/app/src/main/java/com/acon/acon/navigation/nested/OnboardingNavigation.kt
+++ b/app/src/main/java/com/acon/acon/navigation/nested/OnboardingNavigation.kt
@@ -1,12 +1,17 @@
 package com.acon.acon.navigation.nested
 
+import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.navigation
+import androidx.navigation.navArgument
+import androidx.navigation.toRoute
+import com.acon.acon.feature.SettingsRoute
 import com.acon.acon.feature.onboarding.OnboardingRoute
 import com.acon.acon.feature.onboarding.screen.OnboardingScreen.composable.OnboardingContainer
 import com.acon.acon.feature.onboarding.screen.PrefResultLoadingScreen.composable.PrefResultLoadingScreenContainer
+import com.acon.acon.feature.profile.composable.ProfileRoute
 import com.acon.acon.feature.spot.SpotRoute
 
 
@@ -15,15 +20,29 @@ internal fun NavGraphBuilder.onboardingNavigationNavigation(
 ) {
 
     navigation<OnboardingRoute.Graph>(
-        startDestination = OnboardingRoute.OnboardingScreen
+        startDestination = OnboardingRoute.OnboardingScreen.notfromSettings()
     ) {
-        composable<OnboardingRoute.OnboardingScreen> {
+        composable<OnboardingRoute.OnboardingScreen> { backStackEntry ->
+            val args = backStackEntry.toRoute<OnboardingRoute.OnboardingScreen>()
+            val fromSettings = args.fromSettings
+
             OnboardingContainer(
                 navigateToLoadingView = {
                     navController.navigate(OnboardingRoute.LastLoading)
                 },
                 navigateToSpotListView = {
                     navController.navigate(SpotRoute.SpotList)
+                },
+                cancelOnboarding = {
+                    if (fromSettings) { // 스택에 설정이 있는 경우, 즉 설정에서 온보딩으로 들어온 경우
+                        navController.navigate(SettingsRoute.Settings) {
+                            popUpTo(SettingsRoute.Settings) {
+                                inclusive = false
+                            }
+                        }
+                    } else { // 그 이외, 최초 로그인 후 온보딩으로 들어온 경우에 뒤로가기를 누른 경우
+                        navController.popBackStack()
+                    }
                 }
             )
         }
@@ -35,6 +54,5 @@ internal fun NavGraphBuilder.onboardingNavigationNavigation(
                 }
             )
         }
-
     }
 }

--- a/app/src/main/java/com/acon/acon/navigation/nested/SettingsNavigation.kt
+++ b/app/src/main/java/com/acon/acon/navigation/nested/SettingsNavigation.kt
@@ -36,7 +36,7 @@ internal fun NavGraphBuilder.settingsNavigation(
                     }
                 },
                 onNavigateToOnboardingScreen = {
-                    navController.navigate(OnboardingRoute.OnboardingScreen)
+                    navController.navigate(OnboardingRoute.OnboardingScreen.fromSettings())
                 },
                 onNavigateLocalVerificationScreen = {
                     navController.navigate(SettingsRoute.LocalVerification)

--- a/feature/areaverification/src/main/java/com/acon/acon/feature/areaverification/AreaVerificationScreenContainer.kt
+++ b/feature/areaverification/src/main/java/com/acon/acon/feature/areaverification/AreaVerificationScreenContainer.kt
@@ -3,6 +3,7 @@ package com.acon.acon.feature.areaverification
 import android.content.Intent
 import android.net.Uri
 import android.provider.Settings
+import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement

--- a/feature/areaverification/src/main/java/com/acon/acon/feature/areaverification/AreaVerificationScreenContainer.kt
+++ b/feature/areaverification/src/main/java/com/acon/acon/feature/areaverification/AreaVerificationScreenContainer.kt
@@ -62,6 +62,13 @@ fun AreaVerificationScreenContainer(
                     context.startActivity(intent)
                 }
 
+                is AreaVerificationSideEffect.NavigateToGPSSettings -> {
+                    val intent = Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS).apply {
+                        data = Uri.fromParts("package", effect.packageName, null)
+                    }
+                    context.startActivity(intent)
+                }
+
                 is AreaVerificationSideEffect.NavigateToNextScreen -> {
                     onNextScreen(effect.latitude, effect.longitude)
                 }

--- a/feature/areaverification/src/main/java/com/acon/acon/feature/areaverification/AreaVerificationSideEffect.kt
+++ b/feature/areaverification/src/main/java/com/acon/acon/feature/areaverification/AreaVerificationSideEffect.kt
@@ -6,6 +6,10 @@ sealed interface AreaVerificationSideEffect {
         val packageName: String
     ) : AreaVerificationSideEffect
 
+    data class NavigateToGPSSettings(
+        val packageName: String
+    ) : AreaVerificationSideEffect
+
     data class NavigateToNextScreen(
         val latitude: Double,
         val longitude: Double

--- a/feature/areaverification/src/main/java/com/acon/acon/feature/areaverification/AreaVerificationState.kt
+++ b/feature/areaverification/src/main/java/com/acon/acon/feature/areaverification/AreaVerificationState.kt
@@ -15,5 +15,8 @@ data class AreaVerificationState(
     val error: String? = null,
     val areaName: String = "",
     val verifiedArea: Area? = null,
-    val verifiedAreaList: List<Area> = emptyList()
+    val verifiedAreaList: List<Area> = emptyList(),
+
+    val isGPSEnabled: Boolean = false,
+    val showGPSDialog: Boolean = false,
 )

--- a/feature/areaverification/src/main/java/com/acon/acon/feature/areaverification/AreaVerificationState.kt
+++ b/feature/areaverification/src/main/java/com/acon/acon/feature/areaverification/AreaVerificationState.kt
@@ -19,4 +19,7 @@ data class AreaVerificationState(
 
     val isGPSEnabled: Boolean = false,
     val showGPSDialog: Boolean = false,
+
+    val isSupportLocation: Boolean = false,
+    val showLocationDialog: Boolean = false,
 )

--- a/feature/areaverification/src/main/java/com/acon/acon/feature/areaverification/AreaVerificationState.kt
+++ b/feature/areaverification/src/main/java/com/acon/acon/feature/areaverification/AreaVerificationState.kt
@@ -20,6 +20,5 @@ data class AreaVerificationState(
     val isGPSEnabled: Boolean = false,
     val showGPSDialog: Boolean = false,
 
-    val isSupportLocation: Boolean = false,
     val showLocationDialog: Boolean = false,
 )

--- a/feature/areaverification/src/main/java/com/acon/acon/feature/areaverification/AreaVerificationViewModel.kt
+++ b/feature/areaverification/src/main/java/com/acon/acon/feature/areaverification/AreaVerificationViewModel.kt
@@ -27,6 +27,7 @@ class AreaVerificationViewModel @Inject constructor(
     ) {
         fetchVerifiedArea()
         checkGPSStatus()
+        checkSupportLocation(state.latitude, state.longitude)
     }
 
     fun checkGPSStatus() = intent {
@@ -150,6 +151,25 @@ class AreaVerificationViewModel @Inject constructor(
                     )
                 }
             }
+    }
+
+    fun checkSupportLocation(latitude: Double, longitude: Double) = intent {
+        val isSupportLocation = latitude in 33.1..38.6 && longitude in 124.6..131.9
+        reduce {
+            state.copy(isSupportLocation = isSupportLocation)
+        }
+    }
+
+    fun showLocationDialog() = intent {
+        reduce {
+            state.copy(showLocationDialog = true)
+        }
+    }
+
+    fun hideLocationDialog() = intent {
+        reduce {
+            state.copy(showLocationDialog = false)
+        }
     }
 
     fun verifyArea(latitude: Double, longitude: Double) = intent {

--- a/feature/areaverification/src/main/java/com/acon/acon/feature/areaverification/PreferenceMapScreen.kt
+++ b/feature/areaverification/src/main/java/com/acon/acon/feature/areaverification/PreferenceMapScreen.kt
@@ -65,6 +65,8 @@ fun PreferenceMapScreen(
     LaunchedEffect(Unit) {
         viewModel.fetchVerifiedArea()
         viewModel.checkGPSStatus()
+        viewModel.checkSupportLocation(state.latitude, state.longitude)
+
         viewModel.container.sideEffectFlow.collect { effect ->
             when (effect) {
                 is AreaVerificationSideEffect.NavigateToGPSSettings -> {
@@ -78,9 +80,15 @@ fun PreferenceMapScreen(
         }
     }
 
-    LaunchedEffect(state.showGPSDialog){
+    LaunchedEffect(state.isGPSEnabled){
         viewModel.fetchVerifiedArea()
         viewModel.checkGPSStatus()
+    }
+
+    LaunchedEffect(state.isSupportLocation){
+        if(!state.isSupportLocation){
+            viewModel.showLocationDialog()
+        }
     }
 
     if (state.verifiedArea != null) {
@@ -124,6 +132,9 @@ fun PreferenceMapScreen(
             },
             isImageEnabled = false
         )
+    }
+
+    if (state.showLocationDialog){
 
     }
 

--- a/feature/areaverification/src/main/java/com/acon/acon/feature/areaverification/PreferenceMapScreen.kt
+++ b/feature/areaverification/src/main/java/com/acon/acon/feature/areaverification/PreferenceMapScreen.kt
@@ -3,6 +3,7 @@ package com.acon.acon.feature.areaverification
 import android.content.Intent
 import android.net.Uri
 import android.provider.Settings
+import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -65,7 +66,7 @@ fun PreferenceMapScreen(
     LaunchedEffect(Unit) {
         viewModel.fetchVerifiedArea()
         viewModel.checkGPSStatus()
-        viewModel.checkSupportLocation(state.latitude, state.longitude)
+        viewModel.checkSupportLocation(context)
 
         viewModel.container.sideEffectFlow.collect { effect ->
             when (effect) {
@@ -81,14 +82,9 @@ fun PreferenceMapScreen(
     }
 
     LaunchedEffect(state.isGPSEnabled){
-        viewModel.fetchVerifiedArea()
+        //viewModel.fetchVerifiedArea()
         viewModel.checkGPSStatus()
-    }
-
-    LaunchedEffect(state.isSupportLocation){
-        if(!state.isSupportLocation){
-            viewModel.showLocationDialog()
-        }
+        viewModel.checkSupportLocation(context)
     }
 
     if (state.verifiedArea != null) {
@@ -135,7 +131,16 @@ fun PreferenceMapScreen(
     }
 
     if (state.showLocationDialog){
-
+        AconOneButtonDialog(
+            title = "위치 인증 실패",
+            content = "현재 인증이 불가능한 지역에 있어요.",
+            buttonContent = "확인",
+            contentImage = com.acon.acon.core.designsystem.R.drawable.ic_error_2_120,
+            onDismissRequest = {},
+            onClickConfirm = { viewModel.hideLocationDialog() },
+            imageSize = 104.dp,
+            isImageEnabled = true
+        )
     }
 
     Column(

--- a/feature/areaverification/src/main/res/values/strings.xml
+++ b/feature/areaverification/src/main/res/values/strings.xml
@@ -21,4 +21,13 @@
 
     <string name="check_location_on_map">위치 인증</string>
     <string name="verify_complete">인증완료</string>
+
+    <string name="check_gps_title">위치 인식 실패</string>
+    <string name="check_gps_content">문제가 발생했습니다.\n나중에 다시 시도해주세요.</string>
+    <string name="check_gps_ok_btn">확인</string>
+
+    <string name="check_gps_title_2">위치 인식 실패</string>
+    <string name="check_gps_content_2">기기에서 위치 서비스가 비활성화되어 있습니다.\n설정에서 활성화 상태로 변경해주세요.</string>
+    <string name="check_gps_cancel_btn">취소</string>
+    <string name="check_gps_setting_btn">설정으로 가기</string>
 </resources>

--- a/feature/onboarding/src/main/java/com/acon/acon/feature/onboarding/OnboardingRoute.kt
+++ b/feature/onboarding/src/main/java/com/acon/acon/feature/onboarding/OnboardingRoute.kt
@@ -8,7 +8,12 @@ sealed interface OnboardingRoute {
     data object Graph : OnboardingRoute
 
     @Serializable
-    data object OnboardingScreen : OnboardingRoute
+    data class OnboardingScreen(val fromSettings: Boolean = false) : OnboardingRoute {
+        companion object {
+            fun fromSettings() = OnboardingScreen(fromSettings = true)
+            fun notfromSettings() = OnboardingScreen(fromSettings = false)
+        }
+    }
 
     @Serializable
     data object LastLoading : OnboardingRoute

--- a/feature/onboarding/src/main/java/com/acon/acon/feature/onboarding/screen/OnboardingScreen/OnboardingViewModel.kt
+++ b/feature/onboarding/src/main/java/com/acon/acon/feature/onboarding/screen/OnboardingScreen/OnboardingViewModel.kt
@@ -21,6 +21,7 @@ import javax.inject.Inject
 
 private const val ONBOARDING_TOTAL_PAGES = 5;
 
+@Suppress("IMPLICIT_CAST_TO_ANY")
 @HiltViewModel
 class OnboardingViewModel @Inject constructor(
     private val onboardingRepository: OnboardingRepository
@@ -216,9 +217,11 @@ class OnboardingViewModel @Inject constructor(
     }
 
     fun onBackClicked() = intent {
-        val nextPageState = when (state.currentState) {
+        val nextPageState : OnboardingScreenState = when (state.currentState) {
             is OnboardingPageState.Page1State -> {
                 state.copy(
+                    currentPage = 1,
+                    currentState = OnboardingPageState.Page1State()
                 )
             }
             is OnboardingPageState.Page2State -> {
@@ -246,8 +249,11 @@ class OnboardingViewModel @Inject constructor(
                 )
             }
         }
+         reduce { nextPageState ?: state }
 
-        reduce { nextPageState ?: state }
+        if (state.currentState == OnboardingPageState.Page1State()) {
+            postSideEffect(OnboardingScreenSideEffect.CancelOnboarding)
+        }
     }
 
     fun navigateToSpotListView() = intent {
@@ -310,6 +316,7 @@ sealed class OnboardingPageState {
 sealed interface OnboardingScreenSideEffect {
     data object NavigateToLoadingPage: OnboardingScreenSideEffect
     data object NavigateToSpotListView: OnboardingScreenSideEffect
+    data object CancelOnboarding: OnboardingScreenSideEffect
 }
 
 @Parcelize

--- a/feature/onboarding/src/main/java/com/acon/acon/feature/onboarding/screen/OnboardingScreen/composable/OnboardingContainer.kt
+++ b/feature/onboarding/src/main/java/com/acon/acon/feature/onboarding/screen/OnboardingScreen/composable/OnboardingContainer.kt
@@ -1,5 +1,6 @@
 package com.acon.acon.feature.onboarding.screen.OnboardingScreen.composable
 
+import android.util.Log
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -16,7 +17,8 @@ fun OnboardingContainer(
     modifier: Modifier = Modifier,
     viewModel: OnboardingViewModel = hiltViewModel(),
     navigateToLoadingView: () -> Unit = {},
-    navigateToSpotListView: () -> Unit = {}
+    navigateToSpotListView: () -> Unit = {},
+    cancelOnboarding: () -> Unit = {},
 ){
     val state = viewModel.collectAsState().value
 
@@ -36,6 +38,9 @@ fun OnboardingContainer(
             }
             OnboardingScreenSideEffect.NavigateToSpotListView -> {
                 navigateToSpotListView()
+            }
+            OnboardingScreenSideEffect.CancelOnboarding -> {
+                cancelOnboarding()
             }
         }
     }

--- a/feature/onboarding/src/main/java/com/acon/acon/feature/onboarding/screen/OnboardingScreen/composable/OnboardingScreen.kt
+++ b/feature/onboarding/src/main/java/com/acon/acon/feature/onboarding/screen/OnboardingScreen/composable/OnboardingScreen.kt
@@ -38,14 +38,11 @@ fun OnboardingScreen(
     onSkipClicked: () -> Unit = {},
     navigateToNextPage: () -> Unit,
 ){
-    val context = LocalContext.current
-    val activity = context as? Activity
+//    val context = LocalContext.current
+//    val activity = context as? Activity
 
     BackHandler(enabled = true) {
-        when(screenState.currentPage) {
-            1 -> {activity?.finish()}
-            else -> { onBackClicked() }
-        }
+        onBackClicked()
     }
 
     Column(

--- a/feature/profile/src/main/java/com/acon/acon/feature/profile/composable/screen/profileMod/composable/ProfileModScreen.kt
+++ b/feature/profile/src/main/java/com/acon/acon/feature/profile/composable/screen/profileMod/composable/ProfileModScreen.kt
@@ -3,7 +3,6 @@ package com.acon.acon.feature.profile.composable.screen.profileMod.composable
 import android.content.Intent
 import android.net.Uri
 import android.provider.Settings
-import android.util.Log
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background

--- a/feature/settings/src/main/java/com/acon/acon/feature/settings/screen/composable/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/acon/acon/feature/settings/screen/composable/SettingsScreen.kt
@@ -6,6 +6,8 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
@@ -40,6 +42,7 @@ fun SettingsScreen(
     onSignOut: () -> Unit = {},
     onDeleteAccountScreen: () -> Unit = {},
 ) {
+    val scrollState = rememberScrollState()
 
     when(state) {
         is SettingsUiState.Default -> {
@@ -60,6 +63,7 @@ fun SettingsScreen(
                 modifier = modifier
                     .background(AconTheme.color.Gray9)
                     .padding(horizontal = 16.dp)
+                    .verticalScroll(scrollState),
             ) {
                 if(state.isLogin) {
                     Spacer(Modifier.height(42.dp))


### PR DESCRIPTION
## *🧨 Issue*
- closed #29 

## *💻 Work Description*
- [x]  온보딩 (2개 루트) 각각 뒤로가기 시 돌아가는 곳 다름
    - [x]  최초: 두번 뒤로가기 누르면 앱 꺼지게 → 뒤로가기 막는 걸로 변경
    - [x]  설정: 다시 설정으로 돌아오게
- [x]  동네인증할때 (라디오뷰 지나서 맵뷰)
    - [x]  사용자가 **gps 안 킨 경우** : gps 키는 화면이나 설정으로 보내기
        - `PreferenceMapScreen` 들어오자마자 GPS 권한 있는지 확인 → 없으면 다이얼로그 띄우기 → '설정하기’ 버튼 눌러서 설정으로 이동시키기
    - [x]  사용자 **좌표가 외국인 경우** : 다이얼로그 띄우기
    -
## *📸 Screenshot*
-

## *💭 To Reviewers*
-
