### PR TITLE
[Fix] 1차 QA 버그 픽스

### DIFF
--- a/app/src/main/java/com/acon/acon/navigation/AconNavigation.kt
+++ b/app/src/main/java/com/acon/acon/navigation/AconNavigation.kt
@@ -147,16 +147,18 @@ fun AconNavigation(
                                     }
                                 }
                             } else {
-                                selectedBottomNavItem = item
-                                navController.navigate(
-                                    when (item) {
-                                        BottomNavType.SPOT -> SpotRoute.SpotList
-                                        BottomNavType.PROFILE -> ProfileRoute.Profile
-                                        else -> SpotRoute.SpotList
+                                if (selectedBottomNavItem != item) {
+                                    selectedBottomNavItem = item
+                                    navController.navigate(
+                                        when (item) {
+                                            BottomNavType.SPOT -> SpotRoute.SpotList
+                                            BottomNavType.PROFILE -> ProfileRoute.Profile
+                                            else -> SpotRoute.SpotList
+                                        }
+                                    ) {
+                                        popUpTo(SpotRoute.SpotList) { inclusive = false }
+                                        launchSingleTop = true
                                     }
-                                ) {
-                                    popUpTo(SpotRoute.SpotList) { inclusive = false }
-                                    launchSingleTop = true
                                 }
                             }
                         }

--- a/feature/areaverification/src/main/java/com/acon/acon/feature/areaverification/PreferenceMapScreen.kt
+++ b/feature/areaverification/src/main/java/com/acon/acon/feature/areaverification/PreferenceMapScreen.kt
@@ -189,7 +189,7 @@ fun PreferenceMapScreen(
         }
 
         AconFilledLargeButton(
-            text = stringResource(R.string.verify_complete),
+            text = stringResource(R.string.do_verify),
             textStyle = AconTheme.typography.head8_16_sb,
             enabledBackgroundColor = AconTheme.color.Gray5,
             disabledBackgroundColor = AconTheme.color.Gray8,

--- a/feature/areaverification/src/main/java/com/acon/acon/feature/areaverification/component/DottoriSelectionBottomSheet.kt
+++ b/feature/areaverification/src/main/java/com/acon/acon/feature/areaverification/component/DottoriSelectionBottomSheet.kt
@@ -118,7 +118,7 @@ fun DottoriSelectionBottomSheet(
         }
 
         AconFilledLargeButton(
-            text = stringResource(R.string.go_to_home),
+            text = stringResource(R.string.verify_success),
             textStyle = AconTheme.typography.head8_16_sb,
             enabledBackgroundColor = AconTheme.color.Gray5,
             disabledBackgroundColor = AconTheme.color.Gray8,

--- a/feature/areaverification/src/main/res/values/strings.xml
+++ b/feature/areaverification/src/main/res/values/strings.xml
@@ -10,7 +10,7 @@
     <string name="local_dottori_description">로컬 도토리는 본격 맛집을 보증하는 도토리에요.\n만족스러운 식사 후 리뷰에 사용해보세요!</string>
     <string name="local_dottori">로컬 도토리</string>
     <string name="normal_dottori">일반 도토리</string>
-    <string name="go_to_home">홈으로 가기</string>
+    <string name="verify_success">인증 완료</string>
 
     <string name="permission_dialog_title">위치 권한 필요</string>
     <string name="permission_dialog_content">정확한 위치 확인이 필요합니다.\n설정에서 \'정확한 위치\' 권한을 허용해주세요.</string>
@@ -20,7 +20,7 @@
     <string name="next">다음</string>
 
     <string name="check_location_on_map">위치 인증</string>
-    <string name="verify_complete">인증완료</string>
+    <string name="do_verify">인증하기</string>
 
     <string name="check_gps_title">위치 인식 실패</string>
     <string name="check_gps_content">문제가 발생했습니다.\n나중에 다시 시도해주세요.</string>

--- a/feature/settings/src/main/java/com/acon/acon/feature/settings/component/SettingSectionItem.kt
+++ b/feature/settings/src/main/java/com/acon/acon/feature/settings/component/SettingSectionItem.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.acon.acon.core.designsystem.noRippleClickable
 import com.acon.acon.core.designsystem.theme.AconTheme
 import com.acon.acon.feature.settings.type.SettingsType
 import com.acon.acon.feature.settings.R
@@ -33,7 +34,8 @@ fun SettingSectionItem(
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .background(color = AconTheme.color.Gray9),
+            .background(color = AconTheme.color.Gray9)
+            .noRippleClickable { onClickContinue() },
         verticalAlignment = Alignment.CenterVertically
     ) {
         Box(
@@ -66,8 +68,7 @@ fun SettingSectionItem(
             imageVector = ImageVector.vectorResource(com.acon.acon.core.designsystem.R.drawable.ic_arrow_right_20),
             contentDescription = stringResource(R.string.execute_settings_content_description),
             modifier = Modifier
-                .padding(vertical = 6.dp)
-                .clickable { onClickContinue() },
+                .padding(vertical = 6.dp),
             tint = AconTheme.color.Gray4
         )
     }

--- a/feature/settings/src/main/java/com/acon/acon/feature/settings/component/SettingSectionVersionItem.kt
+++ b/feature/settings/src/main/java/com/acon/acon/feature/settings/component/SettingSectionVersionItem.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.acon.acon.core.designsystem.noRippleClickable
 import com.acon.acon.core.designsystem.theme.AconTheme
 import com.acon.acon.feature.settings.type.SettingsType
 import com.acon.acon.feature.settings.R
@@ -35,7 +36,8 @@ fun SettingSectionVersionItem(
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .background(color = AconTheme.color.Gray9),
+            .background(color = AconTheme.color.Gray9)
+            .noRippleClickable { onClickContinue() },
         verticalAlignment = Alignment.CenterVertically
     ) {
         Box(
@@ -86,9 +88,7 @@ fun SettingSectionVersionItem(
                 Spacer(modifier = Modifier.width(4.dp))
                 Icon(
                     imageVector = ImageVector.vectorResource(com.acon.acon.core.designsystem.R.drawable.ic_arrow_right_20),
-                contentDescription = stringResource(R.string.execute_settings_content_description),
-                modifier = Modifier
-                    .clickable { onClickContinue() },
+                    contentDescription = stringResource(R.string.execute_settings_content_description),
                     tint = AconTheme.color.Gray4
                 )
             }

--- a/feature/settings/src/main/java/com/acon/acon/feature/withdraw/component/DeleteAccountTextField.kt
+++ b/feature/settings/src/main/java/com/acon/acon/feature/withdraw/component/DeleteAccountTextField.kt
@@ -12,6 +12,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -35,6 +37,8 @@ fun DeleteAccountTextField(
     modifier: Modifier = Modifier,
     focusRequester: FocusRequester,
     maxLength: Int = 50,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    keyboardActions: KeyboardActions = KeyboardActions.Default
 ) {
     val lineHeight = AconTheme.typography.subtitle1_16_med.lineHeight
     val density = LocalDensity.current
@@ -90,7 +94,9 @@ fun DeleteAccountTextField(
                             }
                             innerTextField()
                         }
-                    }
+                    },
+                    keyboardOptions = keyboardOptions,
+                    keyboardActions = keyboardActions
                 )
             }
         }

--- a/feature/settings/src/main/java/com/acon/acon/feature/withdraw/screen/composable/DeleteAccountScreen.kt
+++ b/feature/settings/src/main/java/com/acon/acon/feature/withdraw/screen/composable/DeleteAccountScreen.kt
@@ -1,6 +1,7 @@
 package com.acon.acon.feature.withdraw.screen.composable
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -14,6 +15,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.relocation.BringIntoViewRequester
 import androidx.compose.foundation.relocation.bringIntoViewRequester
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -31,9 +34,11 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.acon.acon.core.designsystem.blur.LocalHazeState
@@ -98,6 +103,11 @@ fun DeleteAccountScreen(
                     .padding(horizontal = 16.dp)
                     .verticalScroll(scrollState)
                     .hazeSource(LocalHazeState.current)
+                    .pointerInput(Unit) {
+                        detectTapGestures(onTap = {
+                            focusManager.clearFocus()
+                        })
+                    }
             ) {
                 Spacer(Modifier.height(42.dp))
 
@@ -174,6 +184,15 @@ fun DeleteAccountScreen(
                                 onValueChange = { otherReasonText = it },
                                 placeholder = stringResource(R.string.reason_other_placeholder),
                                 focusRequester = focusRequester,
+                                keyboardOptions = KeyboardOptions(
+                                    imeAction = ImeAction.Done
+                                ),
+                                keyboardActions = KeyboardActions(
+                                    onDone = {
+                                        focusManager.clearFocus()
+                                        onUpdateReason(otherReasonText)
+                                    }
+                                ),
                                 modifier = Modifier
                                     .bringIntoViewRequester(bringIntoViewRequester)
                                     .onFocusChanged { state ->

--- a/feature/signin/src/main/java/com/acon/acon/feature/signin/screen/SignInViewModel.kt
+++ b/feature/signin/src/main/java/com/acon/acon/feature/signin/screen/SignInViewModel.kt
@@ -1,5 +1,6 @@
 package com.acon.acon.feature.signin.screen
 
+import android.util.Log
 import com.acon.acon.core.utils.feature.base.BaseContainerHost
 import com.acon.acon.domain.error.user.CredentialException
 import com.acon.acon.domain.repository.UserRepository
@@ -64,11 +65,20 @@ class SignInViewModel @Inject constructor(
     private fun isTokenValid() = intent {
         tokenRepository.getAccessToken().onSuccess { accessToken ->
             if (!accessToken.isNullOrEmpty()) {
-                tokenRepository.getAreaVerification().onSuccess {
-                    postSideEffect(SignInSideEffect.NavigateToSpotListView)
-                }.onFailure {
-                    postSideEffect(SignInSideEffect.NavigateToAreaVerification)
-                }
+                val areaVerificationResult = tokenRepository.getAreaVerification()
+
+                areaVerificationResult.fold(
+                    onSuccess = { isVerified ->
+                        if (isVerified) {
+                            postSideEffect(SignInSideEffect.NavigateToSpotListView)
+                        } else {
+                            postSideEffect(SignInSideEffect.NavigateToAreaVerification)
+                        }
+                    },
+                    onFailure = {
+
+                    }
+                )
             }
         }
     }

--- a/feature/spot/src/main/java/com/acon/acon/feature/spot/screen/spotlist/composable/EmptySpotListView.kt
+++ b/feature/spot/src/main/java/com/acon/acon/feature/spot/screen/spotlist/composable/EmptySpotListView.kt
@@ -34,7 +34,7 @@ fun EmptySpotListView(
         )
         Text(
             text = stringResource(R.string.alert_no_spot),
-            style = AconTheme.typography.body2_14_reg,
+            style = AconTheme.typography.subtitle1_16_med,
             color = AconTheme.color.Gray4,
             modifier = Modifier.padding(top = 24.dp)
         )

--- a/feature/spot/src/main/java/com/acon/acon/feature/spot/screen/spotlist/composable/SpotListScreen.kt
+++ b/feature/spot/src/main/java/com/acon/acon/feature/spot/screen/spotlist/composable/SpotListScreen.kt
@@ -464,7 +464,7 @@ internal fun SpotListScreen(
 
                                     Spacer(modifier = Modifier.height(12.dp))
                                     state.spotList.fastForEachIndexed { index, spot ->
-                                    val isFirstRank = spot === state.spotList.first()
+                                        val isFirstRank = spot === state.spotList.first()
                                         SpotItem(
                                             spot = spot,
                                             isFirstRank = isFirstRank,
@@ -479,22 +479,6 @@ internal fun SpotListScreen(
                                         if (spot !== state.spotList.last())
                                             Spacer(modifier = Modifier.height(12.dp))
                                     }
-                                }
-                                Column(
-                                    modifier = Modifier
-                                        .padding(top = 12.dp)
-                                        .fillMaxWidth()
-                                        .onSizeChanged { size ->
-                                            scrollableInvisibleHeightPx = size.height
-                                        },
-                                    horizontalAlignment = Alignment.CenterHorizontally
-                                ) {
-                                    Text(
-                                        modifier = Modifier.padding(top = 38.dp, bottom = 50.dp),
-                                        text = stringResource(R.string.alert_max_spot_count),
-                                        style = AconTheme.typography.body2_14_reg,
-                                        color = AconTheme.color.Gray5
-                                    )
                                 }
                             }
                         }

--- a/feature/spot/src/main/java/com/acon/acon/feature/spot/screen/spotlist/composable/SpotListScreen.kt
+++ b/feature/spot/src/main/java/com/acon/acon/feature/spot/screen/spotlist/composable/SpotListScreen.kt
@@ -156,7 +156,7 @@ internal fun SpotListScreen(
                                     AvailableWalkingTimeType.UNDER_10_MINUTES -> "10분"
                                     AvailableWalkingTimeType.UNDER_15_MINUTES -> "15분"
                                     AvailableWalkingTimeType.UNDER_20_MINUTES -> "20분"
-                                    AvailableWalkingTimeType.OVER_20_MINUTES -> "20분 이상"
+                                    AvailableWalkingTimeType.OVER_20_MINUTES -> "25분 이상"
                                 }
                                 val isWalkingTimeDefault = it.restaurantWalkingTime == AvailableWalkingTimeType.UNDER_15_MINUTES
                                 amplitudeFilterWalkSlideRestaurant(walkingTime, isWalkingTimeDefault)
@@ -192,7 +192,7 @@ internal fun SpotListScreen(
                                     AvailableWalkingTimeType.UNDER_10_MINUTES -> "10분"
                                     AvailableWalkingTimeType.UNDER_15_MINUTES -> "15분"
                                     AvailableWalkingTimeType.UNDER_20_MINUTES -> "20분"
-                                    AvailableWalkingTimeType.OVER_20_MINUTES -> "20분 이상"
+                                    AvailableWalkingTimeType.OVER_20_MINUTES -> "25분 이상"
                                 }
                                 val isWalkingTimeDefault = it.cafeWalkingTime == AvailableWalkingTimeType.UNDER_15_MINUTES
                                 amplitudeFilterWalkSlideCafe(walkingTime, isWalkingTimeDefault)

--- a/feature/spot/src/main/java/com/acon/acon/feature/spot/screen/spotlist/composable/bottomsheet/SpotFilterBottomSheet.kt
+++ b/feature/spot/src/main/java/com/acon/acon/feature/spot/screen/spotlist/composable/bottomsheet/SpotFilterBottomSheet.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -135,6 +136,27 @@ fun SpotFilterBottomSheet(
         onDismissRequest = onDismissRequest,
         dragHandle = null
     ) {
+        // 필터 선택 여부 확인
+        val isAnyFilterSelected = remember(
+            selectedRestaurantFeatures,
+            selectedCafeFeatures,
+            selectedCompanionTypes,
+            selectedVisitPurposes,
+            selectedRestaurantWalkingTime,
+            selectedCafeWalkingTime,
+            selectedRestaurantPriceRange,
+            selectedCafePriceRange
+        ) {
+            selectedRestaurantFeatures.isNotEmpty() ||
+            selectedCafeFeatures.isNotEmpty() ||
+            selectedCompanionTypes.isNotEmpty() ||
+            selectedVisitPurposes.isNotEmpty() ||
+            selectedRestaurantWalkingTime != AvailableWalkingTimeType.UNDER_15_MINUTES ||
+            selectedCafeWalkingTime != AvailableWalkingTimeType.UNDER_15_MINUTES ||
+            selectedRestaurantPriceRange != RestaurantPriceRangeType.UNDER_10000 ||
+            selectedCafePriceRange != CafePriceRangeType.UNDER_5000
+        }
+
         Box {
             Column(
                 modifier = Modifier
@@ -292,6 +314,7 @@ fun SpotFilterBottomSheet(
                     )
                 },
                 isFilteredResultFetching = isFilteredResultFetching,
+                isAnyFilterSelected = isAnyFilterSelected,
                 composition = lottieComposition,
                 modifier = Modifier
                     .fillMaxWidth()
@@ -355,9 +378,12 @@ private fun BottomCompleteRow(
     onReset: () -> Unit,
     onComplete: () -> Unit,
     isFilteredResultFetching: Boolean,
+    isAnyFilterSelected: Boolean,
     composition: LottieComposition?,
     modifier: Modifier = Modifier
 ) {
+    val isEnabled = isAnyFilterSelected && !isFilteredResultFetching
+
     Row(
         modifier = modifier,
         verticalAlignment = Alignment.CenterVertically
@@ -386,10 +412,10 @@ private fun BottomCompleteRow(
                 .weight(1f)
                 .clip(RoundedCornerShape(6.dp))
                 .background(
-                    color = if (isFilteredResultFetching) AconTheme.color.Gray7 else AconTheme.color.Gray5
+                    color = if (isEnabled) AconTheme.color.Gray5 else AconTheme.color.Gray7
                 ).padding(vertical = 12.dp)
-                .noRippleClickable { if (isFilteredResultFetching.not()) onComplete() },
-            contentAlignment = Alignment.Center
+                .noRippleClickable(enabled = isEnabled) { onComplete() },
+                contentAlignment = Alignment.Center
         ) {
             if (isFilteredResultFetching) {
                 LottieAnimation(
@@ -401,7 +427,7 @@ private fun BottomCompleteRow(
                 Text(
                     text = stringResource(R.string.filter_see_result),
                     style = AconTheme.typography.subtitle1_16_med,
-                    color = AconTheme.color.White
+                    color = if (isEnabled) AconTheme.color.White else AconTheme.color.Gray5
                 )
             }
         }

--- a/feature/spot/src/main/res/values/strings.xml
+++ b/feature/spot/src/main/res/values/strings.xml
@@ -66,7 +66,7 @@
     <string name="under_10_minutes">10분</string>
     <string name="under_15_minutes">15분</string>
     <string name="under_20_minutes">20분</string>
-    <string name="over_20_minutes">20분 이상</string>
+    <string name="over_20_minutes">25분 이상</string>
 
     <string name="under_3000">3천원 이하</string>
     <string name="under_5000">5천원 이하</string>

--- a/feature/upload/src/main/java/com/acon/acon/feature/upload/UploadSuccessContainer.kt
+++ b/feature/upload/src/main/java/com/acon/acon/feature/upload/UploadSuccessContainer.kt
@@ -12,6 +12,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -26,6 +28,7 @@ import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -48,7 +51,6 @@ fun UploadSuccessContainer(
 
     UploadSuccessScreen(
         modifier = modifier,
-        state = state,
         onIntent = viewModel::onIntent,
         onNavigateToSpotList = onNavigateToSpotList
     )
@@ -58,10 +60,10 @@ fun UploadSuccessContainer(
 fun UploadSuccessScreen(
     modifier: Modifier = Modifier,
     onIntent: (UploadIntent) -> Unit,
-    state: UploadState,
     onNavigateToSpotList: () -> Unit
 ) {
     var countdown by remember { mutableIntStateOf(5) }
+    val scrollState = rememberScrollState()
 
     LaunchedEffect(Unit) {
         while (countdown > 0) {
@@ -77,6 +79,7 @@ fun UploadSuccessScreen(
             .background(color = AconTheme.color.Gray9)
             .statusBarsPadding()
             .navigationBarsPadding()
+            .verticalScroll(scrollState)
     ) {
         AconTopBar(
             leadingIcon = {
@@ -156,18 +159,30 @@ fun UploadSuccessScreen(
                     modifier = Modifier.align(Alignment.CenterHorizontally)
                 )
 
-                Spacer(modifier = Modifier.height(16.dp))
+                Spacer(modifier = Modifier.height(12.dp))
                 AconFilledLargeButton(
                     text = "확인",
                     textStyle = AconTheme.typography.head8_16_sb,
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(bottom = 36.dp),
+                        .padding(bottom = 40.dp),
                     disabledBackgroundColor = AconTheme.color.Gray7,
                     enabledBackgroundColor = AconTheme.color.Gray7,
                     onClick = onNavigateToSpotList
                 )
             }
         }
+    }
+}
+
+@Preview
+@Composable
+private fun UploadSuccessScreenPreview() {
+    AconTheme {
+        UploadSuccessScreen(
+            modifier = Modifier,
+            onIntent = {},
+            onNavigateToSpotList = {}
+        )
     }
 }

--- a/feature/upload/src/main/java/com/acon/acon/feature/upload/component/LocationSearchBottomSheet.kt
+++ b/feature/upload/src/main/java/com/acon/acon/feature/upload/component/LocationSearchBottomSheet.kt
@@ -197,9 +197,19 @@ fun LocationSearchBottomSheet(
                                             address = "",
                                             spotType = ""
                                         )
-                                    viewModel.onIntent(UploadIntent.SelectLocation(spotItem))
-                                    onLocationSelected(spotItem)
-                                    onDismiss()
+
+                                    currentLocation?.let { location ->
+                                        processingLocation = spotItem
+                                        viewModel.onIntent(
+                                            UploadIntent.VerifyLocation(
+                                                spotId = suggestion.spotId,
+                                                latitude = location.latitude,
+                                                longitude = location.longitude
+                                            )
+                                        )
+                                    } ?: run {
+                                        showVerificationFailDialog = true
+                                    }
                                 }
                             )
                         }


### PR DESCRIPTION
## *🧨 Issue*
- closed #39 

## *💻 Work Description*
- P1 : 자동로그인 동네인증 여부 검증 로직 수정 (**HOTFIX**)
- P1 : 추천 검색어 목록 선택시 - 선택한 가게의 위치와 사용자 현재 위치가 일치할때만 선택 가능하도록 변경
<hr>

- P2: 바텀네비게이션 메뉴 중복 클릭 방지
- P2 : 업로드 성공 화면 스크롤 되도록 수정
- P2 : 서비스 탈퇴 외부 터치치 / 엔터 입력시 키보드 내리기
- P2: 홈 화면 필터에서 필터링 항목을 선택하지 않았을 경우 배경색/글자색 변경 및 버튼 비활성화 되도록 수정완료
<hr>

- P3 : 동네인증 프로세스 텍스트 변경
- P3 : 설정 선택영역 > 버튼에서 가로 전체 선택영역으로 변경 (전체)
- P3 : 홈 화면 필터 바텀시트 20분 이상 -> 25분 이상으로 UI 라이팅 수정
- P3 : 홈 화면 GUSET로 접속 시 ”장소는 최대 6순위까지만 제공됩니다” 문구 삭제

## *💭 To Reviewers*
- QA 시트 특이사항 읽어주세요
